### PR TITLE
add: ジャーナリング・購入判断の登録機能を追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!
-  before_action :prevent_access_after_decision, only: [:purchase_decision]
+  before_action :prevent_access_after_decision, only: [ :purchase_decision ]
 
   def index
     @items = current_user.items.order(created_at: :desc)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,8 +32,8 @@ class ItemsController < ApplicationController
 
     if @item.save
       if choice == "skip"
-        # ! 後で変更(クールダウンスキップ時は購入判断画面に遷移) !
-        redirect_to item_path(@item), flash: { success: t("flash.items.create.success") }
+        # クールダウンスキップ時は購入判断画面に遷移
+        redirect_to purchase_decision_item_path(@item), flash: { success: t("flash.items.create.success") }
       else
         # クールダウンタイマー使用時はアイテム詳細画面に遷移
         redirect_to item_path(@item), flash: { success: t("flash.items.create.success") }
@@ -51,7 +51,7 @@ class ItemsController < ApplicationController
   def update
     @item = current_user.items.find(params[:id])
     if @item.update(item_params)
-      redirect_to @item, success: t("flash.items.update.success")
+      redirect_to item_path(@item), success: t("flash.items.update.success")
     else
       flash.now[:alert] = t("flash.items.update.failure")
       render :edit, status: :unprocessable_entity
@@ -68,13 +68,111 @@ class ItemsController < ApplicationController
     redirect_to item_path(item), alert: t("flash.items.destroy.failure")
   end
 
+  # フォーム表示用
+  def purchase_decision
+    @item = current_user.items.find(params[:id])
+
+    @journal = @item.latest_draft_journal || @item.journals.build
+  end
+
+  # フォーム送信・保存用
+  def submit_decision
+    @item = current_user.items.find(params[:id])
+    commit_type = params[:commit_type]
+
+    case commit_type
+
+    # 下書き保存
+    when "draft"
+      save_or_update_draft
+      redirect_to item_path(@item), success: t("flash.items.decide.success.draft")
+
+    # 購入判断完了
+    when "complete"
+      status_params = params.dig(:item, :status)
+
+      if status_params.blank?
+        # バリデーションエラー(購入判断完了時は「買う・買わない」の選択が必要)
+        @item.errors.add(:status, "「買う」「買わない」のどちらかを選択してください")
+        build_journal_from_params
+        flash.now[:alert] = t("flash.items.decide.failure")
+        render :purchase_decision, status: :unprocessable_entity
+      else
+        # バリデーションOK(購入判断「買う・買わない」を選択済み)
+        if @item.update(status: status_params)
+          finalize_journal
+          redirect_to dashboards_path, success: t("flash.items.decide.success.complete")
+        else
+          build_journal_from_params
+          flash.now[:alert] = t("flash.items.decide.failure")
+          render :purchase_decision, status: :unprocessable_entity
+        end
+      end
+    end
+  end
+
   private
 
+  # クールダウンタイマー実装時に使用
   def ensure_ready_for_decision
     redirect_to items_path, alert: "まだ次のステップに進めません" unless @item.ready_for_decision?
   end
 
+  # 下書き保存
+  def save_or_update_draft
+    return if journal_content.blank?
+
+    draft_journal = @item.latest_draft_journal
+
+    if draft_journal.present?
+      # 下書きがある場合は更新
+      draft_journal.update!(content: journal_content)
+    else
+      # 下書きが無い場合は新規作成
+      @item.journals.create!(
+        content: journal_content,
+        is_draft: true
+      )
+    end
+  end
+
+  # 購入判断完了ボタンをクリック後、バリデーションOK
+  def finalize_journal
+    return if journal_content.blank?
+
+    draft_journal = @item.latest_draft_journal
+
+    if draft_journal.present?
+      # 下書きがある場合は更新
+      draft_journal.update!(
+        content: journal_content,
+        is_draft: false
+      )
+      # 古い下書きを削除
+      @item.journals.where(is_draft: true).where.not(id: draft_journal.id).destroy_all
+    else
+
+      # 下書きが無い場合は新規作成
+      draft_journal = @item.journals.create!(
+        content: journal_content,
+        is_draft: false
+      )
+    end
+  end
+
+  def build_journal_from_params
+    @journal = Journal.new(
+      content: journal_content
+    )
+  end
+
   def item_params
-    params.require(:item).permit(:name, :note, :cooldown_duration)
+    params.require(:item).permit(
+      :name, :note, :cooldown_duration, :status, :journal_content
+      )
+  end
+
+  def journal_content
+    params.dig(:item, :journal_content)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!
+  before_action :prevent_access_after_decision, only: [:purchase_decision]
 
   def index
     @items = current_user.items.order(created_at: :desc)
@@ -93,7 +94,7 @@ class ItemsController < ApplicationController
 
       if status_params.blank?
         # バリデーションエラー(購入判断完了時は「買う・買わない」の選択が必要)
-        @item.errors.add(:status, "「買う」「買わない」のどちらかを選択してください")
+        @item.errors.add(:status, t("flash.items.decide.validation.status_required"))
         build_journal_from_params
         flash.now[:alert] = t("flash.items.decide.failure")
         render :purchase_decision, status: :unprocessable_entity
@@ -164,6 +165,14 @@ class ItemsController < ApplicationController
     @journal = Journal.new(
       content: journal_content
     )
+  end
+
+  # 購入判断済みの場合はリダイレクト
+  def prevent_access_after_decision
+    @item = current_user.items.find(params[:id])
+    if @item.decided?
+      redirect_to item_path(@item), alert: t("flash.items.decide.access_denied.after_decision")
+    end
   end
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,6 @@
 class Item < ApplicationRecord
+  before_update :set_decided_at
+
   validates :name, presence: true, length: { maximum: 255 }
   validates :note, length: { maximum: 65_535 }
   validate :cooldown_choice_valid
@@ -7,6 +9,7 @@ class Item < ApplicationRecord
   enum :cooldown_duration, { minutes_30: 0, hours_24: 1, days_3: 2 }
 
   belongs_to :user
+  has_many :journals, dependent: :destroy
 
   # アイテムのステータスを確認
   def cooldown_not_selected?
@@ -39,9 +42,9 @@ class Item < ApplicationRecord
     case status
     when "thinking"
       if cooldown_not_selected?
-        { label: "クールダウン設定", path: "#" }
+        { label: "クールダウン設定", type: :cooldown }
       elsif ready_for_decision?
-        { label: "判断する", path: "#" }
+        { label: "判断する", type: :decision }
       end
     end
   end
@@ -72,8 +75,17 @@ class Item < ApplicationRecord
     self.cooldown_duration = nil
   end
 
+  def latest_draft_journal
+    journals.where(is_draft: true).order(created_at: :desc).first
+  end
+
   private
 
+  def set_decided_at
+    self.decided_at = Time.current if decided? && decided_at.nil?
+  end
+
+  # アイテム登録時はクールダウン期間の選択が必要
   def cooldown_choice_valid
     if cooldown_duration.blank? && cooldown_until.blank?
       errors.add(:cooldown_duration, "を選択してください")

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,0 +1,7 @@
+class Journal < ApplicationRecord
+  validates :is_draft, inclusion: { in: [ true, false ] }
+
+  belongs_to :item
+
+  scope :published, -> { where(is_draft: false) }
+end

--- a/app/views/items/_next_action_button.html.erb
+++ b/app/views/items/_next_action_button.html.erb
@@ -1,3 +1,14 @@
 <% if item.next_action.present? %>
-  <%= link_to item.next_action[:label], item.next_action[:path], class: "btn-base" %>
+  <% action = item.next_action %>
+
+  <% path =
+    case action[:type]
+    when :cooldown
+      "#"
+    when :decision
+      purchase_decision_item_path(item)
+    end
+  %>
+
+  <%= link_to action[:label], path, class: "btn-base" %>
 <% end %>

--- a/app/views/items/purchase_decision.html.erb
+++ b/app/views/items/purchase_decision.html.erb
@@ -1,0 +1,114 @@
+<div class="max-w-3xl mx-auto my-8 px-4">
+  <div class="bg-white rounded-xl shadow px-8 py-10 space-y-11">
+    <h1 class="text-2xl font-bold mt-2 mb-9 text-center">購入を判断する</h1>
+
+    <!-- アイテム情報 -->
+    <div class="bg-base-200 rounded-lg opacity-90">
+      <div class="p-1 ml-2">
+        <p class="font-medium"><%= @item.name %></p>
+
+        <ion-icon name="calendar-outline" class="text-sm translate-y-[2px]"></ion-icon>
+        <span class="text-sm">
+          <%= @item.created_at.strftime("%Y/%-m/%-d") %>
+          <span class="mx-0.5"></span>
+          <%= @item.created_at.strftime("%-H:%M") %>に登録
+        </span>
+      </div>
+    </div>
+
+    <%= form_with model: @item, url: submit_decision_item_path(@item), method: :patch, local: true do |f| %>
+
+      <!-- 質問（任意回答） -->
+
+      <!-- ジャーナリング（任意回答） -->
+      <div class="space-y-2">
+        <h2 class="block text-sm font-medium mb-2">ジャーナリング（任意）</h2>
+        <p class="text-xs mt-1">
+          このアイテムを手にすることで、あなたの日常はどのように彩られますか？<br>
+          思いつくままに、浮かんできたことを書き出してみましょう。
+        </p>
+
+        <%= f.text_area "journal_content",
+            value: @journal&.content,
+            class: "textarea textarea-bordered w-full focus:outline-none" %>
+      </div>
+
+      <div class="border-t border-base-300 my-12"></div>
+
+      <!-- 購入判断 -->
+      <div class="space-y-4">
+        <p class="text-sm text-center">気持ちは決まりましたか？</p>
+
+        <div class="grid grid-cols-2 gap-6 max-w-xs mx-auto">
+
+          <!-- 買う -->
+          <label class="cursor-pointer group w-full">
+            <%= f.radio_button :status, "decided_buy", class: "hidden peer" %>
+
+            <div class="flex items-center gap-2 px-4 py-2 border border-accent rounded-lg
+                        text-lg
+                        peer-checked:border-accent peer-checked:bg-accent/20
+                        transition">
+
+              <ion-icon name="radio-button-off-outline"
+                        class="group-has-[input:checked]:hidden text-accent"></ion-icon>
+
+              <ion-icon name="radio-button-on-outline"
+                        class="hidden group-has-[input:checked]:inline text-accent"></ion-icon>
+
+              <span class="font-medium text-accent">買う</span>
+            </div>
+          </label>
+
+          <!-- 買わない -->
+          <label class="cursor-pointer group w-full">
+            <%= f.radio_button :status, "decided_skip", class: "hidden peer" %>
+
+            <div class="flex items-center gap-2 px-4 py-2 border border-info/90 rounded-lg
+                        text-lg
+                        peer-checked:border-info peer-checked:bg-info/20
+                        transition">
+
+              <ion-icon name="radio-button-off-outline"
+                        class="group-has-[input:checked]:hidden text-info"></ion-icon>
+
+              <ion-icon name="radio-button-on-outline"
+                        class="hidden group-has-[input:checked]:inline text-info"></ion-icon>
+
+              <span class="font-medium text-info">買わない</span>
+            </div>
+          </label>
+        </div>
+
+        <!-- 選択必須のメッセージ -->
+        <% if @item.errors[:status].any? %>
+          <div class="mt-5 flex justify-center">
+            <div class="bg-error/10 border border-error/30 text-error px-4 py-2 rounded-full text-sm font-medium">
+              <ion-icon name="alert-circle-outline" class="mr-1 text-lg translate-y-[3px]"></ion-icon>
+              <%= @item.errors[:status].first %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="border-t border-base-300 my-12"></div>
+
+      <!-- ボタン -->
+      <div class="flex flex-col items-center gap-6">
+        <button type="submit" name="commit_type" value="complete"
+                class="btn-base min-w-[160px]">
+          判断を完了する
+        </button>
+
+        <button type="submit" name="commit_type" value="draft"
+                class="btn-base opacity-60 text-white min-w-[160px]">
+          下書き保存
+        </button>
+
+        <%= link_to "保存せずに終了",
+          item_path(@item),
+          class: "btn btn-outline min-w-[160px]" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -61,12 +61,16 @@
       </p>
     </div>
 
-    <!-- ジャーナリング入力内容を追加 -->
+    <!-- ジャーナリング -->
     <div class="bg-gray-50 rounded-lg p-4 space-y-2">
       <p class="text-xs font-bold opacity-90">ジャーナリング</p>
-      <p class="text-sm">
-        入力した内容を表示します。
-      </p>
+      <div class="text-sm leading-relaxed">
+        <% @item.journals.published.each do |journal| %>
+          <% if journal.content.present? %>
+            <%= simple_format(journal.content) %>
+          <% end %>
+        <% end %>
+      </div>
     </div>
 
     <!-- アイテム編集・削除・一覧に遷移するボタン -->

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,3 +13,8 @@ ja:
         success: "削除しました"
         failure: "削除できませんでした"
       not_found: "アイテムが見つかりません"
+      decide:
+        success:
+          complete: "購入判断を保存しました。おつかれさまでした！"
+          draft: "下書きを保存しました"
+        failure: "保存できませんでした"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -18,3 +18,7 @@ ja:
           complete: "購入判断を保存しました。おつかれさまでした！"
           draft: "下書きを保存しました"
         failure: "保存できませんでした"
+        validation:
+          status_required: "「買う」「買わない」のどちらかを選択してください"
+        access_denied:
+          after_decision: "すでに購入判断は完了しています"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,12 @@ Rails.application.routes.draw do
   devise_for :users
   root "static_pages#top"
   resource :dashboards, only: [ :show ]
-  resources :items, only: %i[index show new create edit update destroy]
+  resources :items, only: %i[index show new create edit update destroy] do
+    member do
+      get :purchase_decision
+      patch :submit_decision
+    end
+  end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20260402155901_create_journals.rb
+++ b/db/migrate/20260402155901_create_journals.rb
@@ -1,0 +1,12 @@
+class CreateJournals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :journals do |t|
+      t.text :content
+      t.boolean :is_draft, null: false, default: true
+
+      t.references :item, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_31_090420) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_02_155901) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,6 +29,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_31_090420) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
+  create_table "journals", force: :cascade do |t|
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.boolean "is_draft", default: true, null: false
+    t.bigint "item_id"
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_journals_on_item_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -43,4 +52,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_31_090420) do
   end
 
   add_foreign_key "items", "users"
+  add_foreign_key "journals", "items"
 end

--- a/spec/factories/journals.rb
+++ b/spec/factories/journals.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :journal do
+  end
+end

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Journal, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### 概要
購入判断画面(ジャーナリング+購入判断の登録機能)を作成しました。

### 内容
- Journalsテーブルを作成
- 購入判断画面を作成
- ジャーナリング+購入判断の登録機能を追加
- ジャーナリングの下書き機能を追加
- 購入判断画面への画面遷移を追加

### 確認事項
- [x] ジャーナリング(任意項目)は未入力でも登録できる
- [x] ジャーナリングが未入力の場合はDBに保存されない
- [x] 購入判断登録後は、購入判断画面に遷移できない

closes #19