### PR TITLE
add: 質問回答の登録機能を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,7 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
 #   Enabled: false
+
+AllCops:
+  Exclude:
+    - 'db/migrate/*.rb'

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -72,8 +72,23 @@ class ItemsController < ApplicationController
   # フォーム表示用
   def purchase_decision
     @item = current_user.items.find(params[:id])
-
     @journal = @item.latest_draft_journal || @item.journals.build
+    @questions = Question.where(user_id: nil).order(:position)
+    @answers_map = @item.answers.where(is_draft: true).index_by(&:question_id)
+
+    # フォーム送信後(paramsがある場合)は params 優先で上書き
+    if answers_params.present?
+      answers_params.each do |question_id_str, answer_param|
+        question_id = question_id_str.to_i
+        choice = answer_param["choice"]
+        next if choice.blank?
+
+        @answers_map[question_id] = Answer.new(
+          question_id: question_id,
+          choice: choice
+        )
+      end
+    end
   end
 
   # フォーム送信・保存用
@@ -95,16 +110,27 @@ class ItemsController < ApplicationController
       if status_params.blank?
         # バリデーションエラー(購入判断完了時は「買う・買わない」の選択が必要)
         @item.errors.add(:status, t("flash.items.decide.validation.status_required"))
+
+        @item.assign_attributes(item_params)
+
+        @questions = Question.where(user_id: nil).order(:position)
+        @answers_map = build_answers_from_params
+
         build_journal_from_params
+
         flash.now[:alert] = t("flash.items.decide.failure")
         render :purchase_decision, status: :unprocessable_entity
       else
         # バリデーションOK(購入判断「買う・買わない」を選択済み)
-        if @item.update(status: status_params)
+        if @item.update(status: status_params) # 登録成功
           finalize_journal
+          finalize_answers
           redirect_to dashboards_path, success: t("flash.items.decide.success.complete")
-        else
+        else # 登録失敗
+          @item.assign_attributes(item_params)
+          @answers_map = build_answers_from_params
           build_journal_from_params
+
           flash.now[:alert] = t("flash.items.decide.failure")
           render :purchase_decision, status: :unprocessable_entity
         end
@@ -121,6 +147,37 @@ class ItemsController < ApplicationController
 
   # 下書き保存
   def save_or_update_draft
+    save_item_draft_fields
+    save_answers_draft
+    save_journal_draft
+  end
+
+  def save_item_draft_fields
+    draft_attributes = {}
+    draft_attributes[:desire_level] = params.dig(:item, :desire_level) if params.dig(:item, :desire_level).present?
+    draft_attributes[:current_mood] = params.dig(:item, :current_mood) if params.dig(:item, :current_mood).present?
+
+    return if draft_attributes.empty?
+
+    @item.update!(draft_attributes)
+  end
+
+  def save_answers_draft
+    return if answers_params.blank?
+
+    answers_params.each do |_, answer_param|
+      next if answer_param[:choice].blank?
+
+      question_id = answer_param["question_id"]
+      answer = @item.answers.find_or_initialize_by(question_id: question_id)
+
+      answer.choice = answer_param[:choice]
+      answer.is_draft = true
+      answer.save!
+    end
+  end
+
+  def save_journal_draft
     return if journal_content.blank?
 
     draft_journal = @item.latest_draft_journal
@@ -137,7 +194,37 @@ class ItemsController < ApplicationController
     end
   end
 
+  # 購入判断完了ボタンをクリック後、失敗(バリデーションエラーまたは登録失敗)
+  def build_answers_from_params
+    return {} if answers_params.blank?
+
+    answers_map = {}
+
+    answers_params.each do |question_id_str, answer_param|
+      question_id = question_id_str.to_i
+      choice = answer_param["choice"]
+      next if choice.blank?
+
+      answers_map[question_id] = Answer.new(
+        question_id: question_id,
+        choice: choice
+      )
+    end
+
+    answers_map
+  end
+
+  def build_journal_from_params
+    @journal = Journal.new(
+      content: journal_content
+    )
+  end
+
   # 購入判断完了ボタンをクリック後、バリデーションOK
+  def finalize_answers
+    @item.answers.update_all(is_draft: false)
+  end
+
   def finalize_journal
     return if journal_content.blank?
 
@@ -161,12 +248,6 @@ class ItemsController < ApplicationController
     end
   end
 
-  def build_journal_from_params
-    @journal = Journal.new(
-      content: journal_content
-    )
-  end
-
   # 購入判断済みの場合はリダイレクト
   def prevent_access_after_decision
     @item = current_user.items.find(params[:id])
@@ -176,12 +257,19 @@ class ItemsController < ApplicationController
   end
 
   def item_params
+    # permit : 必須チェック(無いとエラー)
     params.require(:item).permit(
-      :name, :note, :cooldown_duration, :status, :journal_content
-      )
+      :name, :note, :cooldown_duration, :status, :desire_level, :current_mood
+    )
+  end
+
+  def answers_params
+    #  fetch : 無くてもデフォルト値{}を返すのでエラーにならない
+    params.fetch(:answers, {}).permit!.to_h
   end
 
   def journal_content
+    # dig : 無くてもnilを返すのでエラーにならない(ネストを安全に取得)
     params.dig(:item, :journal_content)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -265,7 +265,9 @@ class ItemsController < ApplicationController
 
   def answers_params
     #  fetch : 無くてもデフォルト値{}を返すのでエラーにならない
-    params.fetch(:answers, {}).permit!.to_h
+    params.fetch(:answers, {}).transform_values do |answer|
+      answer.permit(:choice, :question_id)
+    end
   end
 
   def journal_content

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,6 @@
+class Answer < ApplicationRecord
+  enum choice: { yes: 0, unknown: 1, no: 2 }
+
+  belongs_to :item
+  belongs_to :question
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,4 +1,6 @@
 class Answer < ApplicationRecord
+  validates :is_draft, inclusion: { in: [ true, false ] }
+
   enum choice: { yes: 0, unknown: 1, no: 2 }
 
   belongs_to :item

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,4 +1,5 @@
 class Answer < ApplicationRecord
+  validates :question_id, uniqueness: { scope: :item_id }
   validates :is_draft, inclusion: { in: [ true, false ] }
 
   enum choice: { yes: 0, unknown: 1, no: 2 }

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -2,7 +2,7 @@ class Answer < ApplicationRecord
   validates :question_id, uniqueness: { scope: :item_id }
   validates :is_draft, inclusion: { in: [ true, false ] }
 
-  enum choice: { yes: 0, unknown: 1, no: 2 }
+  enum :choice, { yes: 0, unknown: 1, no: 2 }
 
   belongs_to :item
   belongs_to :question

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,6 +10,7 @@ class Item < ApplicationRecord
 
   belongs_to :user
   has_many :journals, dependent: :destroy
+  has_many :answers, dependent: :destroy
 
   # アイテムのステータスを確認
   def cooldown_not_selected?

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,4 @@
+class Question < ApplicationRecord
+  belongs_to :user
+  has_many :answers, dependent: :destroy
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,4 +1,7 @@
 class Question < ApplicationRecord
+  validates :position, presence: true, uniqueness: { scope: :user_id }
+  validates :content, presence: true
+
   belongs_to :user
   has_many :answers, dependent: :destroy
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -2,6 +2,6 @@ class Question < ApplicationRecord
   validates :position, presence: true, uniqueness: { scope: :user_id }
   validates :content, presence: true
 
-  belongs_to :user
+  belongs_to :user, optional: true
   has_many :answers, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,5 @@ class User < ApplicationRecord
                        message: "は英数字を混ぜて入力してください" }
 
   has_many :items, dependent: :destroy
+  has_many :questions, dependent: :destroy
 end

--- a/app/views/items/purchase_decision.html.erb
+++ b/app/views/items/purchase_decision.html.erb
@@ -1,6 +1,12 @@
 <div class="max-w-3xl mx-auto my-8 px-4">
   <div class="bg-white rounded-xl shadow px-8 py-10 space-y-11">
-    <h1 class="text-2xl font-bold mt-2 mb-9 text-center">購入を判断する</h1>
+    <div class="mt-2 mb-9 text-center">
+      <h1 class="text-2xl font-bold ">購入を判断する</h1>
+      <p class="text-sm mt-4">
+        もしよろしければ、質問を活用しながら<br>
+        買うかどうかを考えてみてください。
+      </p>
+    </div>
 
     <!-- アイテム情報 -->
     <div class="bg-base-200 rounded-lg opacity-90">
@@ -19,17 +25,89 @@
     <%= form_with model: @item, url: submit_decision_item_path(@item), method: :patch, local: true do |f| %>
 
       <!-- 質問（任意回答） -->
+      <h2 class="font-medium mb-5">質問から、気になった理由・買う理由を探してみる（任意）</h2>
+      <div class="space-y-4 mb-15 max-w-xl mx-auto">
+
+        <!-- 欲しい度 -->
+        <div class="space-y-2 text-center mb-8">
+          <p class="text-sm font-medium leading-relaxed">
+            どのくらい欲しいと感じますか？<br>
+            （1：欲しくない　～　5：とても欲しい）
+          </p>
+
+          <%= f.range_field :desire_level,
+            min: 1, max: 5, step: 1,
+            class: "range range-accent flex-1" %>
+
+          <div class="flex justify-between text-xs px-2 max-w-xs mx-auto">
+            <span>1</span><span>2</span><span>3</span><span>4</span><span>5</span>
+          </div>
+        </div>
+
+        <!-- 今の気分 -->
+        <div class="space-y-2 text-center mb-5">
+          <p class="text-sm font-medium leading-relaxed">
+            今の気分はどうですか？<br>
+            （1：疲れている　～　5：元気）
+          </p>
+
+          <%= f.range_field :current_mood,
+              min: 1, max: 5, step: 1,
+              class: "range range-info w-full max-w-xs mx-auto" %>
+
+          <div class="flex justify-between text-xs px-2 max-w-xs mx-auto">
+            <span>1</span><span>2</span><span>3</span><span>4</span><span>5</span>
+          </div>
+        </div>
+
+        <!-- 質問（8問） -->
+        <% @questions.each do |question| %>
+          <div class="bg-base-100 border rounded-lg p-3 text-center">
+
+            <p class="mb-3 text-sm font-medium">
+              <%= question.content %>
+            </p>
+
+            <div class="flex justify-center gap-2 max-w-xs mx-auto">
+              <div class="flex gap-5">
+                <% Answer.choices.keys.each do |key| %> <!-- Answer.choices.keysは["yes", "unknown", "no"] -->
+                  <% labels = { yes: "はい", unknown: "わからない", no: "いいえ" } %>
+                  <% label = labels[key.to_sym] %>
+
+                  <% checked = (@answers_map[question.id]&.choice == key) %> <!-- @answers_mapはユーザーの回答(例: "yes") -->
+
+                  <label class="cursor-pointer">
+                    <%= radio_button_tag "answers[#{question.id}][choice]", key,
+                        checked,
+                        class: "hidden peer" %>
+
+                    <%= hidden_field_tag "answers[#{question.id}][question_id]", question.id %>
+
+                    <div class="px-4 py-1 border rounded-full text-xs
+                                peer-checked:bg-primary peer-checked:text-white">
+                      <%= label %>
+                    </div>
+                  </label>
+                <% end %>
+              </div>
+            </div>
+
+          </div>
+        <% end %>
+      </div>
 
       <!-- ジャーナリング（任意回答） -->
       <div class="space-y-2">
-        <h2 class="block text-sm font-medium mb-2">ジャーナリング（任意）</h2>
-        <p class="text-xs mt-1">
+        <h2 class="block font-medium mt-10 mb-2">ジャーナリングで、購入判断のきっかけを引き出してみる（任意）</h2>
+        <p class="text-xs mt-1 leading-relaxed">
           このアイテムを手にすることで、あなたの日常はどのように彩られますか？<br>
-          思いつくままに、浮かんできたことを書き出してみましょう。
+          内容は良いことでも悪いことでも、短くても長くても大丈夫です。<br>
+          あなたの考えや欲しい理由など、思いつくままに浮かんできたことを書き出してみましょう。
         </p>
 
         <%= f.text_area "journal_content",
             value: @journal&.content,
+            rows:  6,
             class: "textarea textarea-bordered w-full focus:outline-none" %>
       </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -44,6 +44,10 @@
       <div class="text-sm leading-relaxed">
         <% if @item.note.present? %>
           <%= simple_format(@item.note) %>
+        <% else %>
+          <p class="text-sm text-gray-400 italic">
+            まだ登録されていません
+          </p>
         <% end %>
       </div>
     </div>
@@ -51,24 +55,72 @@
     <!-- 質問回答を追加 -->
     <div class="bg-gray-50 rounded-lg p-4 space-y-2">
       <p class="text-xs font-bold opacity-90">質問</p>
-      <p class="text-sm leading-relaxed">
-        回答した内容を表示します。<br>
-        質問1<br>
-        質問2<br>
-        質問3<br>
-        質問4<br>
-        質問5
-      </p>
+      <div class="text-sm font-medium leading-relaxed">
+
+        <!-- 欲しい度・今の気分 -->
+        <div class="flex gap-2">
+          <div class="flex flex-col gap-2">
+            <p class="opacity-90">どのくらい欲しい？</p>
+            <p class="opacity-90">気分は良い？</p>
+          </div>
+          <div class="flex flex-col gap-2.5">
+            <div class="rating rating-sm">
+              <% 1.upto(5) do |i| %>
+                <%= tag.input type: "radio",
+                              class: "mask mask-star-2 bg-accent",
+                              checked: (@item.desire_level == i),
+                              disabled: true %>
+              <% end %>
+            </div>
+
+            <div class="rating rating-sm">
+              <% 1.upto(5) do |i| %>
+                <%= tag.input type: "radio",
+                              class: "mask mask-star-2 bg-accent",
+                              checked: (@item.current_mood == i),
+                              disabled: true %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+
+        <!-- 質問（8問） -->
+        <div>
+          <% @item.answers.where(is_draft: false).each do |answer| %>
+            <div class="mt-3 mb-3">
+              <p class="text-sm opacity-90">
+                <%= answer.question.content %>
+              </p>
+
+              <div class="flex gap-2 mt-1">
+                <% Answer.choices.keys.each do |key| %>
+                  <% selected = answer.choice == key %>
+
+                  <span class="px-3 py-1 rounded-full text-xs border
+                    <%= selected ? 'bg-primary text-white' : 'opacity-40' %>">
+                    <%= { yes: "はい", unknown: "わからない", no: "いいえ" }[key.to_sym] %>
+                  </span>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+
+      </div>
     </div>
 
     <!-- ジャーナリング -->
     <div class="bg-gray-50 rounded-lg p-4 space-y-2">
       <p class="text-xs font-bold opacity-90">ジャーナリング</p>
       <div class="text-sm leading-relaxed">
-        <% @item.journals.published.each do |journal| %>
-          <% if journal.content.present? %>
-            <%= simple_format(journal.content) %>
+        <% if @item.journals.published.any? %>
+          <% @item.journals.published.each do |journal| %>
+            <%= simple_format(journal.content) if journal.content.present? %>
           <% end %>
+        <% else %>
+          <p class="text-sm text-gray-400 italic">
+            まだ登録されていません
+          </p>
         <% end %>
       </div>
     </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -55,40 +55,46 @@
     <!-- 質問回答を追加 -->
     <div class="bg-gray-50 rounded-lg p-4 space-y-2">
       <p class="text-xs font-bold opacity-90">質問</p>
-      <div class="text-sm font-medium leading-relaxed">
+      <div class="text-sm leading-relaxed">
 
         <!-- 欲しい度・今の気分 -->
         <div class="flex gap-2">
-          <div class="flex flex-col gap-2">
-            <p class="opacity-90">どのくらい欲しい？</p>
-            <p class="opacity-90">気分は良い？</p>
-          </div>
-          <div class="flex flex-col gap-2.5">
-            <div class="rating rating-sm">
-              <% 1.upto(5) do |i| %>
-                <%= tag.input type: "radio",
-                              class: "mask mask-star-2 bg-accent",
-                              checked: (@item.desire_level == i),
-                              disabled: true %>
-              <% end %>
+          <% if @item.decided? %>
+            <div class="flex flex-col gap-2 font-medium">
+              <p class="opacity-90">どのくらい欲しい？</p>
+              <p class="opacity-90">気分は良い？</p>
             </div>
+            <div class="flex flex-col gap-2.5">
+              <div class="rating rating-sm">
+                <% 1.upto(5) do |i| %>
+                  <%= tag.input type: "radio",
+                                class: "mask mask-star-2 bg-accent",
+                                checked: (@item.desire_level == i),
+                                disabled: true %>
+                <% end %>
+              </div>
 
-            <div class="rating rating-sm">
-              <% 1.upto(5) do |i| %>
-                <%= tag.input type: "radio",
-                              class: "mask mask-star-2 bg-accent",
-                              checked: (@item.current_mood == i),
-                              disabled: true %>
-              <% end %>
+              <div class="rating rating-sm">
+                <% 1.upto(5) do |i| %>
+                  <%= tag.input type: "radio",
+                                class: "mask mask-star-2 bg-accent",
+                                checked: (@item.current_mood == i),
+                                disabled: true %>
+                <% end %>
+              </div>
             </div>
-          </div>
+          <% else %>
+            <p class="text-sm text-gray-400 italic">
+              まだ登録されていません
+            </p>
+          <% end %>
         </div>
 
         <!-- 質問（8問） -->
         <div>
           <% @item.answers.where(is_draft: false).each do |answer| %>
             <div class="mt-3 mb-3">
-              <p class="text-sm opacity-90">
+              <p class="text-sm font-medium opacity-90">
                 <%= answer.question.content %>
               </p>
 

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -6,3 +6,4 @@ npm run build:css:prod
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
+bundle exec rails db:seed

--- a/db/migrate/20260405122138_create_questions.rb
+++ b/db/migrate/20260405122138_create_questions.rb
@@ -1,0 +1,11 @@
+class CreateQuestions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :questions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :content, null: false
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260405122243_create_answers.rb
+++ b/db/migrate/20260405122243_create_answers.rb
@@ -1,0 +1,12 @@
+class CreateAnswers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :answers do |t|
+      t.references :item, null: false, foreign_key: true
+      t.references :question, null: false, foreign_key: true
+      t.integer :choice
+      t.boolean :is_draft
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260405122343_add_columns_to_items.rb
+++ b/db/migrate/20260405122343_add_columns_to_items.rb
@@ -1,0 +1,8 @@
+class AddColumnsToItems < ActiveRecord::Migration[8.1]
+  def change
+    change_table :items, bulk: true do |t|
+      t.integer :desire_level
+      t.integer :current_mood
+    end
+  end
+end

--- a/db/migrate/20260405125116_add_not_null_to_journals_item_id.rb
+++ b/db/migrate/20260405125116_add_not_null_to_journals_item_id.rb
@@ -1,0 +1,5 @@
+class AddNotNullToJournalsItemId < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :journals, :item_id, false
+  end
+end

--- a/db/migrate/20260405125538_add_default_to_answers_is_draft.rb
+++ b/db/migrate/20260405125538_add_default_to_answers_is_draft.rb
@@ -1,0 +1,6 @@
+class AddDefaultToAnswersIsDraft < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :answers, :is_draft, true
+    change_column_null :answers, :is_draft, false
+  end
+end

--- a/db/migrate/20260405143254_change_user_id_null_on_questions.rb
+++ b/db/migrate/20260405143254_change_user_id_null_on_questions.rb
@@ -1,0 +1,5 @@
+class ChangeUserIdNullOnQuestions < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :questions, :user_id, true
+  end
+end

--- a/db/migrate/20260405143459_add_unique_index_to_questions.rb
+++ b/db/migrate/20260405143459_add_unique_index_to_questions.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToQuestions < ActiveRecord::Migration[8.1]
+  def change
+    add_index :questions, [:user_id, :position], unique: true
+  end
+end

--- a/db/migrate/20260405144531_add_unique_index_to_answers.rb
+++ b/db/migrate/20260405144531_add_unique_index_to_answers.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToAnswers < ActiveRecord::Migration[8.1]
+  def change
+    add_index :answers, [:item_id, :question_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_05_125538) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_05_144531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -21,6 +21,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_05_125538) do
     t.bigint "item_id", null: false
     t.bigint "question_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["item_id", "question_id"], name: "index_answers_on_item_id_and_question_id", unique: true
     t.index ["item_id"], name: "index_answers_on_item_id"
     t.index ["question_id"], name: "index_answers_on_question_id"
   end
@@ -56,7 +57,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_05_125538) do
     t.datetime "created_at", null: false
     t.integer "position", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
+    t.index ["user_id", "position"], name: "index_questions_on_user_id_and_position", unique: true
     t.index ["user_id"], name: "index_questions_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_02_155901) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_05_122343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "answers", force: :cascade do |t|
+    t.integer "choice"
+    t.datetime "created_at", null: false
+    t.boolean "is_draft"
+    t.bigint "item_id", null: false
+    t.bigint "question_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_answers_on_item_id"
+    t.index ["question_id"], name: "index_answers_on_question_id"
+  end
 
   create_table "items", force: :cascade do |t|
     t.integer "cooldown_duration"
     t.datetime "cooldown_until"
     t.datetime "created_at", null: false
+    t.integer "current_mood"
     t.datetime "decided_at"
+    t.integer "desire_level"
     t.string "name", null: false
     t.text "note"
     t.datetime "notified_at"
@@ -38,6 +51,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_155901) do
     t.index ["item_id"], name: "index_journals_on_item_id"
   end
 
+  create_table "questions", force: :cascade do |t|
+    t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.integer "position", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_questions_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", default: "", null: false
@@ -51,6 +73,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_02_155901) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "answers", "items"
+  add_foreign_key "answers", "questions"
   add_foreign_key "items", "users"
   add_foreign_key "journals", "items"
+  add_foreign_key "questions", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_05_122343) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_05_125538) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "answers", force: :cascade do |t|
     t.integer "choice"
     t.datetime "created_at", null: false
-    t.boolean "is_draft"
+    t.boolean "is_draft", default: true, null: false
     t.bigint "item_id", null: false
     t.bigint "question_id", null: false
     t.datetime "updated_at", null: false
@@ -46,7 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_05_122343) do
     t.text "content"
     t.datetime "created_at", null: false
     t.boolean "is_draft", default: true, null: false
-    t.bigint "item_id"
+    t.bigint "item_id", null: false
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_journals_on_item_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,21 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# db/seeds.rb
+default_questions = [
+  "似た商品をすでに持っていますか？",
+  "今すぐ必要なものですか？",
+  "他の商品に比べて安いと感じますか？",
+  "購入しても収入や貯蓄に余裕はありますか？",
+  "今の気分が欲しい気持ちに影響していると感じますか？",
+  "購入しないと後悔すると思いますか？",
+  "他の商品や方法で、代わりになる可能性はありますか？",
+  "購入することであなたにとって良い影響がありますか？"
+]
+
+questions.each_with_index do |content, position|
+  question = Question.find_or_initialize_by(user_id: nil, position: position)
+  question.content = content
+  question.save!
+end

--- a/spec/factories/answers.rb
+++ b/spec/factories/answers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :answer do
+    item { nil }
+    question { nil }
+    choice { 1 }
+    is_draft { false }
+  end
+end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :question do
+    user { nil }
+    content { "MyText" }
+    position { 1 }
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Answer, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Question, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### 概要
質問回答の登録機能を作成しました。

### 内容
- Questionsテーブルの作成
- Answersテーブルの作成
- カラムの設定を変更(以前のテーブル作成時に抜けていた外部キーにnot_null制約の追加)
- デフォルト質問(seed)を作成
- 質問回答の登録機能を追加
- 質問回答の下書き機能を追加
- アイテム詳細画面を修正

### 確認事項
- [x] 購入判断未選択時はエラーメッセージを表示する
- [x] バリデーションエラー時にそれまでの入力内容を一時的に保持・表示する(DB保存はされない)
- [x] 本番環境にseedが反映される

closes #16