### PR TITLE
add: クールダウンタイマー機能を追加

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -2,5 +2,9 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def show
+    items = current_user.items
+    @thinking_count     = items.thinking.count
+    @decided_buy_count  = items.decided_buy.count
+    @decided_skip_count = items.decided_skip.count
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -2,9 +2,49 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    items = current_user.items
+    items = current_user.items.includes(:answers, :journals)
+
+    # 登録済みアイテムをカウント
     @thinking_count     = items.thinking.count
     @decided_buy_count  = items.decided_buy.count
     @decided_skip_count = items.decided_skip.count
+
+    # 今できることの提案（検討中のアイテムをステータスごとに表示）
+
+    # クールダウン中のアイテム
+    # スキップ選択時は後からタイマーを使う場合があるため、表示を最優先（クールダウン中は購入判断を行えない）
+    cooldown_items_full = items
+      .thinking
+      .select(&:cooldown_active?)
+
+    cooldown_ids = cooldown_items_full.map(&:id)
+    @cooldown_items = cooldown_items_full.last(5)
+    @cooldown_items_more = cooldown_items_full.size > 5
+
+    # 下書き中のアイテム
+    draft_items_full = items
+      .thinking
+      .reject { |item| cooldown_ids.include?(item.id) }
+      .select { |item| draft_item?(item) }
+
+    draft_ids = draft_items_full.map(&:id)
+    @draft_items = draft_items_full.last(5)
+    @draft_items_more = draft_items_full.size > 5
+
+    # クールダウンが完了したアイテム
+    # 下書き中アイテムとの二重表示を除外
+    ready_items_full = items
+      .thinking
+      .reject { |item| cooldown_ids.include?(item.id) || draft_ids.include?(item.id) }
+      .select(&:ready_for_decision?)
+
+    @ready_items = ready_items_full.last(5)
+    @ready_items_more = ready_items_full.size > 5
+  end
+
+  private
+
+  def draft_item?(item)
+    item.journals.any?(&:is_draft) || item.answers.any?(&:is_draft)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!
-  before_action :prevent_access_after_decision, only: [ :purchase_decision ]
+  before_action :set_item, only: [ :show, :edit, :update, :destroy, :purchase_decision, :submit_decision ]
+  before_action :ensure_ready_for_decision, only: [ :purchase_decision, :submit_decision ]
+  before_action :prevent_access_after_decision, only: [ :purchase_decision, :submit_decision ]
 
   def index
     @items = current_user.items.order(created_at: :desc)
@@ -10,12 +12,7 @@ class ItemsController < ApplicationController
     end
   end
 
-  def show
-    @item = Item.find(params[:id])
-    redirect_to items_path, alert: t("flash.items.not_found") unless @item.user == current_user
-  rescue ActiveRecord::RecordNotFound
-    redirect_to items_path, alert: t("flash.items.not_found")
-  end
+  def show; end
 
   def new
     @item = Item.new
@@ -45,12 +42,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  def edit
-    @item = current_user.items.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @item = current_user.items.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path(@item), success: t("flash.items.update.success")
     else
@@ -60,18 +54,14 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = current_user.items.find(params[:id])
-    item.destroy!
+    @item.destroy!
     redirect_to items_path, success: t("flash.items.destroy.success")
-  rescue ActiveRecord::RecordNotFound
-    redirect_to items_path, alert: t("flash.items.not_found")
   rescue ActiveRecord::RecordNotDestroyed
-    redirect_to item_path(item), alert: t("flash.items.destroy.failure")
+    redirect_to item_path(@item), alert: t("flash.items.destroy.failure")
   end
 
   # フォーム表示用
   def purchase_decision
-    @item = current_user.items.find(params[:id])
     @journal = @item.latest_draft_journal || @item.journals.build
     @questions = Question.where(user_id: nil).order(:position)
     @answers_map = @item.answers.where(is_draft: true).index_by(&:question_id)
@@ -93,7 +83,6 @@ class ItemsController < ApplicationController
 
   # フォーム送信・保存用
   def submit_decision
-    @item = current_user.items.find(params[:id])
     commit_type = params[:commit_type]
 
     case commit_type
@@ -139,11 +128,6 @@ class ItemsController < ApplicationController
   end
 
   private
-
-  # クールダウンタイマー実装時に使用
-  def ensure_ready_for_decision
-    redirect_to items_path, alert: "まだ次のステップに進めません" unless @item.ready_for_decision?
-  end
 
   # 下書き保存
   def save_or_update_draft
@@ -248,12 +232,24 @@ class ItemsController < ApplicationController
     end
   end
 
-  # 購入判断済みの場合はリダイレクト
-  def prevent_access_after_decision
+  def set_item
     @item = current_user.items.find(params[:id])
-    if @item.decided?
-      redirect_to item_path(@item), alert: t("flash.items.decide.access_denied.after_decision")
-    end
+  rescue ActiveRecord::RecordNotFound
+    redirect_to items_path, alert: t("flash.items.not_found")
+  end
+
+  # クールダウン完了前は、購入判断画面に遷移できない
+  def ensure_ready_for_decision
+    return if @item.ready_for_decision?
+
+    redirect_to item_path(@item), alert: t("flash.items.decide.access_denied.cooldown_active")
+  end
+
+  # 購入判断完了後は、購入判断画面に遷移できない
+  def prevent_access_after_decision
+    return unless @item.decided?
+
+    redirect_to item_path(@item), alert: t("flash.items.decide.access_denied.after_decision")
   end
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_item, only: [ :show, :edit, :update, :destroy, :purchase_decision, :submit_decision ]
+  before_action :set_item, except: [ :index, :new, :create ]
+  before_action :ensure_cooldown_not_set, only: [ :cooldown, :set_cooldown ]
   before_action :ensure_ready_for_decision, only: [ :purchase_decision, :submit_decision ]
   before_action :prevent_access_after_decision, only: [ :purchase_decision, :submit_decision ]
 
@@ -60,6 +61,30 @@ class ItemsController < ApplicationController
     redirect_to item_path(@item), alert: t("flash.items.destroy.failure")
   end
 
+  # クールダウンタイマー（スキップ時）
+  # 表示
+  def cooldown
+  end
+
+  # 登録
+  def set_cooldown
+    choice = params[:cooldown_choice]
+
+    unless choice.present?
+      @item.errors.add(:cooldown_duration, "を選択してください")
+      return render :cooldown, status: :unprocessable_entity
+    end
+
+    if Item.cooldown_durations.key?(choice)
+      @item.update!(cooldown_duration: choice)
+      redirect_to item_path(@item), success: t("flash.items.cooldown.success")
+    else
+      flash.now[:alert] = t("flash.items.cooldown.failure")
+      render :cooldown, status: :unprocessable_entity
+    end
+  end
+
+  # 購入判断
   # フォーム表示用
   def purchase_decision
     @journal = @item.latest_draft_journal || @item.journals.build
@@ -221,6 +246,13 @@ class ItemsController < ApplicationController
     @item = current_user.items.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     redirect_to items_path, alert: t("flash.items.not_found")
+  end
+
+  # 既にクールダウンタイマーを使用している場合は遷移できない
+  def ensure_cooldown_not_set
+    return if @item.cooldown_duration.nil?
+
+    redirect_to item_path(@item), alert: t("flash.items.cooldown.validation.already_used")
   end
 
   # クールダウン完了前は、購入判断画面に遷移できない

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,7 +29,9 @@ class ItemsController < ApplicationController
       @item.cooldown_duration = choice
     end
 
-    if @item.save
+    begin
+      @item.save!
+
       if choice == "skip"
         # クールダウンスキップ時は購入判断画面に遷移
         redirect_to purchase_decision_item_path(@item), flash: { success: t("flash.items.create.success") }
@@ -37,7 +39,12 @@ class ItemsController < ApplicationController
         # クールダウンタイマー使用時はアイテム詳細画面に遷移
         redirect_to item_path(@item), flash: { success: t("flash.items.create.success") }
       end
-    else
+
+    rescue ActiveRecord::RecordInvalid
+      render :new, status: :unprocessable_entity
+
+    rescue => e
+      Rails.logger.error(e)
       flash.now[:alert] = t("flash.items.create.failure")
       render :new, status: :unprocessable_entity
     end
@@ -46,9 +53,15 @@ class ItemsController < ApplicationController
   def edit; end
 
   def update
-    if @item.update(item_params)
+    begin
+      @item.update!(item_params)
       redirect_to item_path(@item), success: t("flash.items.update.success")
-    else
+
+    rescue ActiveRecord::RecordInvalid
+      render :edit, status: :unprocessable_entity
+
+    rescue => e
+      Rails.logger.error(e)
       flash.now[:alert] = t("flash.items.update.failure")
       render :edit, status: :unprocessable_entity
     end
@@ -123,7 +136,7 @@ class ItemsController < ApplicationController
 
       # バリデーションエラー(購入判断完了時は「買う・買わない」の選択が必要)
       if status_params.blank?
-        @item.errors.add(:status, t("flash.items.decide.validation.status_required"))
+        @item.errors.add(:base, t("flash.items.decide.validation.status_required"))
 
         @item.assign_attributes(item_params)
 
@@ -132,7 +145,6 @@ class ItemsController < ApplicationController
 
         build_journal_from_params
 
-        flash.now[:alert] = t("flash.items.decide.failure")
         render :purchase_decision, status: :unprocessable_entity
 
       # バリデーションOK(購入判断「買う・買わない」を選択済み)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
   before_action :set_item, except: [ :index, :new, :create ]
   before_action :ensure_cooldown_not_set, only: [ :cooldown, :set_cooldown ]
   before_action :ensure_ready_for_decision, only: [ :purchase_decision, :submit_decision ]
-  before_action :prevent_access_after_decision, only: [ :purchase_decision, :submit_decision ]
+  before_action :prevent_access_after_decision, only: [ :cooldown, :set_cooldown, :purchase_decision, :submit_decision ]
 
   def index
     @items = current_user.items.order(created_at: :desc)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -4,7 +4,7 @@ class Item < ApplicationRecord
   before_update :set_decided_at
   before_save :set_cooldown_until, if: :will_save_change_to_cooldown_duration?
 
-  validates :name, presence: true, length: { maximum: 255 }
+  validates :name, presence: true, length: { maximum: 70 }
   validates :note, length: { maximum: 65_535 }
   validate :cooldown_choice_valid
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,8 @@
 class Item < ApplicationRecord
+  include ActionView::Helpers::DateHelper
+
   before_update :set_decided_at
+  before_save :set_cooldown_until, if: :will_save_change_to_cooldown_duration?
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :note, length: { maximum: 65_535 }
@@ -11,6 +14,11 @@ class Item < ApplicationRecord
   belongs_to :user
   has_many :journals, dependent: :destroy
   has_many :answers, dependent: :destroy
+
+  scope :cooldown_finished_unnotified, -> {
+    where("cooldown_until <= ?", Time.current)
+      .where(notified_at: nil)
+  }
 
   # アイテムのステータスを確認
   def cooldown_not_selected?
@@ -70,10 +78,68 @@ class Item < ApplicationRecord
     end
   end
 
+  # 設定したクールダウン期間・完了までの残り時間を表示
+  def cooldown_status_text
+    if cooldown_active?
+      "#{cooldown_duration_text}のクールダウン中 (#{remaining_time_text})"
+    elsif cooldown_skipped?
+      "クールダウンは設定されていません"
+    elsif cooldown_finished?
+      "#{cooldown_duration_text}のクールダウンが終わりました"
+    end
+  end
+
+  def cooldown_duration_text
+    I18n.t("activerecord.enums.item.cooldown_duration.#{cooldown_duration}") if cooldown_duration.present?
+  end
+
+  def remaining_time_text
+    return "" unless cooldown_until
+
+    seconds = (cooldown_until - Time.current).to_i
+    return "あと1分" if seconds < 60
+
+    days = (seconds / 1.day.to_f).ceil
+    hours = (seconds / 1.hour.to_f).ceil
+    minutes = (seconds / 1.minute.to_f).ceil
+
+    if seconds >= 1.days
+      # 24時間以上～3日以下 → 切り上げ日表示
+      "あと#{days}日"
+    elsif seconds >= 1.hour
+      # 1時間以上～24時間未満 → 切り上げ時間表示
+      "あと#{hours}時間"
+    else
+      # 1分以上～1時間未満 → 切り上げ分表示
+      "あと#{minutes}分"
+    end
+  end
+
+  # クールダウンタイマーの設定
+  # 現在時刻から指定した期間までの時間を取得
+  def set_cooldown_until
+    return if cooldown_duration.blank?
+
+    self.cooldown_until =
+      case cooldown_duration
+      when "minutes_30"
+        30.minutes.from_now
+      when "hours_24"
+        24.hours.from_now
+      when "days_3"
+        3.days.from_now
+      end
+  end
+
   # クールダウンタイマーをスキップ(今回は設定しない)
   def skip_cooldown!
     self.cooldown_until = Time.current
     self.cooldown_duration = nil
+  end
+
+  # クールダウンタイマー通知済みに変更
+  def mark_as_notified!
+    update!(notified_at: Time.current)
   end
 
   def latest_draft_journal

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -139,8 +139,13 @@ class Item < ApplicationRecord
 
   private
 
+  # 初回の購入判断後にdecided_atカラムを更新
   def set_decided_at
-    self.decided_at = Time.current if decided? && decided_at.nil?
+    return unless will_save_change_to_status?
+    return unless status_was == "thinking"
+    return unless decided?
+
+    self.decided_at ||= Time.current
   end
 
   # アイテム登録時はクールダウン期間の選択が必要

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -61,12 +61,12 @@ class Item < ApplicationRecord
   def next_action_message
     case status
     when "thinking"
-      if cooldown_not_selected?
-        "クールダウンタイマーを設定して、次のステップに進みましょう"
+      if cooldown_skipped?
+        "クールダウンタイマーの設定か、購入判断に進むことができます"
       elsif cooldown_active?
         "クールダウンが終わるまで、ひと休みしましょう"
       elsif ready_for_decision?
-        "ジャーナリングと購入判断に進むことができます"
+        "購入判断に進むことができます"
       end
     end
   end
@@ -74,23 +74,14 @@ class Item < ApplicationRecord
   # クールダウンタイマーの時間選択
   def cooldown_options_for_select
     self.class.cooldown_durations.keys.map do |key|
-      [ I18n.t("activerecord.enums.item.cooldown_duration.#{key}"), key ]
-    end
-  end
-
-  # 設定したクールダウン期間・完了までの残り時間を表示
-  def cooldown_status_text
-    if cooldown_active?
-      "#{cooldown_duration_text}のクールダウン中 (#{remaining_time_text})"
-    elsif cooldown_skipped?
-      "クールダウンは設定されていません"
-    elsif cooldown_finished?
-      "#{cooldown_duration_text}のクールダウンが終わりました"
+      [ I18n.t("activerecord.enums.item.cooldown_duration.#{key}.label"),
+        key,
+        I18n.t("activerecord.enums.item.cooldown_duration.#{key}.description") ]
     end
   end
 
   def cooldown_duration_text
-    I18n.t("activerecord.enums.item.cooldown_duration.#{cooldown_duration}") if cooldown_duration.present?
+    I18n.t("activerecord.enums.item.cooldown_duration.#{cooldown_duration}.label") if cooldown_duration.present?
   end
 
   def remaining_time_text

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,10 +21,6 @@ class Item < ApplicationRecord
   }
 
   # アイテムのステータスを確認
-  def cooldown_not_selected?
-    cooldown_duration.nil? && cooldown_until.nil?
-  end
-
   def cooldown_skipped?
     cooldown_duration.nil? && cooldown_until.present?
     # クールダウンをスキップ時は、cooldown_untilに現在時刻を入れる
@@ -42,29 +38,23 @@ class Item < ApplicationRecord
     cooldown_skipped? || cooldown_finished?
   end
 
-  def decided?
-    decided_buy? || decided_skip?
+  def drafted?
+    journals.exists?(is_draft: true) || answers.exists?(is_draft: true)
   end
 
-  # ステータスごとに、次のステップを表示
-  def next_action
-    case status
-    when "thinking"
-      if cooldown_not_selected?
-        { label: "クールダウン設定", type: :cooldown }
-      elsif ready_for_decision?
-        { label: "判断する", type: :decision }
-      end
-    end
+  def decided?
+    decided_buy? || decided_skip?
   end
 
   def next_action_message
     case status
     when "thinking"
       if cooldown_skipped?
-        "クールダウンタイマーの設定か、購入判断に進むことができます"
+        "クールダウンタイマーのセットか、購入判断に進むことができます"
       elsif cooldown_active?
         "クールダウンが終わるまで、ひと休みしましょう"
+      elsif drafted?
+        "購入判断を再開できます"
       elsif ready_for_decision?
         "購入判断に進むことができます"
       end
@@ -106,7 +96,7 @@ class Item < ApplicationRecord
     end
   end
 
-  # クールダウンタイマーの設定
+  # クールダウンタイマーのセット
   # 現在時刻から指定した期間までの時間を取得
   def set_cooldown_until
     return if cooldown_duration.blank?
@@ -122,7 +112,7 @@ class Item < ApplicationRecord
       end
   end
 
-  # クールダウンタイマーをスキップ(今回は設定しない)
+  # クールダウンタイマーをスキップ(今回はセットしない)
   def skip_cooldown!
     self.cooldown_until = Time.current
     self.cooldown_duration = nil

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,4 +1,5 @@
 class Journal < ApplicationRecord
+  validates :content, length: { maximum: 65_535 }
   validates :is_draft, inclusion: { in: [ true, false ] }
   validate :only_one_draft_per_item
 

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,13 +1,15 @@
 <div class="container-main space-y-8">
 
-  <!-- ヘッダー -->
   <div class="flex items-center justify-between">
-    <h1 class="text-2xl md:text-3xl font-bold">ダッシュボード</h1>
+    <h1 class="text-2xl md:text-3xl font-bold opacity-90">H O M E</h1>
 
-    <%= link_to '＋ 登録', new_item_path, class: "btn-base btn-xl text-lg" %>
+    <div class="flex gap-6">
+      <%= link_to 'リスト', items_path, class: "btn btn-outline btn-xl text-lg" %>
+      <%= link_to '＋ 登録', new_item_path, class: "btn-base btn-xl text-lg" %>
+    </div>
   </div>
 
-  <!-- サマリーカード -->
+  <!-- 登録済みアイテムをカウント -->
   <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
 
     <div class="card-base">
@@ -39,45 +41,62 @@
 
   </div>
 
-  <!-- メインリスト -->
-  <div class="card bg-base-200 shadow-sm">
-    <div class="card-body">
+  <!-- 今できることの提案 -->
 
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="card-title">最近気になったもの</h2>
-        <%= link_to "すべて見る", items_path, class: "btn btn-outline" %>
-      </div>
-
-      <ul class="space-y-4">
-
-        <li class="flex items-center justify-between p-3 rounded-lg bg-base-100">
-          <div>
-            <p class="font-medium">アイテム1</p>
-            <p class="text-sm opacity-70">クールダウン完了</p>
-          </div>
-          <button class="btn btn-sm btn-ghost">詳細</button>
-        </li>
-
-        <li class="flex items-center justify-between p-3 rounded-lg bg-base-100">
-          <div>
-            <p class="font-medium">アイテム2</p>
-            <p class="text-sm opacity-70">下書き中</p>
-          </div>
-          <button class="btn btn-sm btn-ghost">詳細</button>
-        </li>
-
-        <li class="flex items-center justify-between p-3 rounded-lg bg-base-100">
-          <div>
-            <p class="font-medium">アイテム3</p>
-            <p class="text-sm opacity-70">クールダウン中</p>
-          </div>
-          <button class="btn btn-sm btn-ghost">詳細</button>
-        </li>
-
-      </ul>
-
+  <!-- 下書き中のアイテム -->
+  <% if @draft_items.present? %>
+    <div class="flex flex-col rounded-sm p-6 bg-base-200 space-y-5">
+      <h3 class="text-sm">回答途中のアイテムがあります。購入判断を再開しましょう。</h3>
+      <% @draft_items.each do |item| %>
+        <%= render 'items/compact_card', item: item %>
+      <% end %>
+      <% if @draft_items_more %>
+        <div class="flex justify-center">
+          <%= link_to "すべて見る", items_path(status: "thinking"), class: "text-sm font-medium flex items-center gap-1" %>
+        </div>
+      <% end %>
     </div>
-  </div>
+  <% end %>
+
+  <!-- クールダウンが完了したアイテム -->
+  <% if @ready_items.present? %>
+    <div class="flex flex-col rounded-sm p-6 bg-base-200 space-y-5">
+      <h3 class="text-sm">クールダウンが完了しました。買うかどうか、考えてみますか？</h3>
+      <% @ready_items.each do |item| %>
+        <%= render 'items/compact_card', item: item %>
+      <% end %>
+      <% if @ready_items_more %>
+        <div class="flex justify-center">
+          <%= link_to "すべて見る", items_path(status: "thinking"), class: "text-sm font-medium flex items-center gap-1" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <!-- クールダウン中のアイテム -->
+  <% if @cooldown_items.present? %>
+    <div class="flex flex-col rounded-sm p-6 bg-info/30 space-y-5">
+      <h3 class="text-sm">クールダウンが終わるまで、ひと休みしましょう。</h3>
+      <% @cooldown_items.each do |item| %>
+        <%= render 'items/compact_card', item: item %>
+      <% end %>
+      <% if @cooldown_items_more %>
+        <div class="flex justify-center">
+          <%= link_to "すべて見る", items_path(status: "thinking"), class: "text-sm font-medium flex items-center gap-1" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <!-- 待機中のアイテムが無い -->
+  <% if @draft_items.empty? && @ready_items.empty? && @cooldown_items.empty? %>
+    <div class="card-base">
+      <div class="card-body text-center py-6 bg-base-200 text-sm leading-relaxed">
+        <h3>商品を登録すると、こちらに表示されます。</h3>
+        <p>新しく登録してみましょう。</p>
+      </div>
+    </div>
+  <% end %>
 
   <!-- アクション -->
   <div class="card-base">

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -13,21 +13,27 @@
     <div class="card-base">
       <div class="card-body">
         <h2 class="card-title text-sm">検討中</h2>
-        <p class="text-2xl font-bold">5</p>
+        <p class="text-2xl font-bold">
+          <%= @thinking_count %>
+        </p>
       </div>
     </div>
 
     <div class="card-base">
       <div class="card-body">
         <h2 class="card-title text-sm">買う</h2>
-        <p class="text-2xl font-bold">2</p>
+        <p class="text-2xl font-bold">
+          <%= @decided_buy_count %>
+        </p>
       </div>
     </div>
 
     <div class="card-base">
       <div class="card-body">
         <h2 class="card-title text-sm">買わない</h2>
-        <p class="text-2xl font-bold">3</p>
+        <p class="text-2xl font-bold">
+          <%= @decided_skip_count %>
+        </p>
       </div>
     </div>
 

--- a/app/views/items/_card.html.erb
+++ b/app/views/items/_card.html.erb
@@ -35,14 +35,14 @@
       </div>
 
       <!-- 右列 -->
-      <div class="flex flex-col items-end h-full mt-1 gap-5">
+      <div class="flex flex-col items-end h-full mt-1 ml-1 gap-5">
 
         <!-- 次できるアクションに遷移するボタン -->
         <div class="btn-sm mt-auto">
           <% if item.decided? || item.cooldown_active? %>
             <button class="invisible btn"></button>
           <% else %>
-            <%= render 'items/next_action_button', item: item %>
+            <%= render 'items/next_action_button', item: item, button_class: "btn-base min-w-[100px]" %>
           <% end %>
         </div>
 

--- a/app/views/items/_card.html.erb
+++ b/app/views/items/_card.html.erb
@@ -11,10 +11,20 @@
           <%= item.name %>
         </h2>
 
-        <!-- アイテム登録日 -->
-        <div class="text-sm mt-1">
-          <ion-icon name="calendar-outline" class="text-base translate-y-[2px]"></ion-icon>
-          <span><%= item.created_at.strftime("%Y/%-m/%-d") %>に登録</span>
+        <div class="flex text-sm mt-1 gap-4">
+          <!-- アイテム登録日 -->
+          <div class="flex gap-1">
+            <ion-icon name="calendar-outline" class="text-base translate-y-[2px]"></ion-icon>
+            <span><%= item.created_at.strftime("%Y/%-m/%-d") %>に登録</span>
+          </div>
+
+          <!-- クールダウンタイマー残り時間 -->
+          <div class="flex">
+            <% if item.cooldown_active? %>
+              <ion-icon name="hourglass-outline" class="text-base translate-y-[2px]"></ion-icon>
+              <p><%= item.remaining_time_text %></p>
+            <% end %>
+          </div>
         </div>
 
         <!-- ステータスバッジ + 次にできることを案内 -->

--- a/app/views/items/_card.html.erb
+++ b/app/views/items/_card.html.erb
@@ -1,14 +1,14 @@
-<div class="card bg-base-100 shadow">
+<div class="card bg-white shadow">
   <div class="card-body">
 
     <div class="flex justify-between items-stretch">
 
       <!-- 左列 -->
-      <div class="flex flex-1 min-w-0 flex-col">
+      <div class="flex flex-1 min-w-0 flex-col justify-center">
 
         <!-- アイテム名 -->
-        <h2 class="card-title truncate">
-          <%= item.name %>
+        <h2 class="card-title">
+          <%= link_to item.name, item_path(item), class: "hover:underline font-semibold block truncate" %>
         </h2>
 
         <div class="flex text-sm mt-1 gap-4">
@@ -30,7 +30,7 @@
         <!-- ステータスバッジ + 次にできることを案内 -->
         <div class="mt-3 flex flex-col gap-1 sm:flex-row sm:items-center">
           <%= render 'items/status_badge', item: item %>
-          <p class="text-xs"><%= item.next_action_message %></p>
+          <p class="text-xs ml-1"><%= item.next_action_message %></p>
         </div>
       </div>
 
@@ -38,8 +38,8 @@
       <div class="flex flex-col items-end h-full mt-1 gap-5">
 
         <!-- 次できるアクションに遷移するボタン -->
-        <div class="btn-sm">
-          <% if item.next_action.nil? %>
+        <div class="btn-sm mt-auto">
+          <% if item.decided? || item.cooldown_active? %>
             <button class="invisible btn"></button>
           <% else %>
             <%= render 'items/next_action_button', item: item %>

--- a/app/views/items/_compact_card.html.erb
+++ b/app/views/items/_compact_card.html.erb
@@ -1,0 +1,31 @@
+<div class="card bg-white shadow">
+  <div class="card-body">
+
+    <div class="flex justify-between items-center">
+
+      <!-- 左列 -->
+      <div class="flex-1 min-w-0">
+
+        <!-- アイテム名 -->
+        <h2 class="card-title">
+          <%= link_to item.name, item_path(item), class: "hover:underline block truncate" %>
+        </h2>
+      </div>
+
+      <!-- 右列 -->
+      <div class="flex-shrink-0 ml-3">
+
+        <!-- 次できるアクションに遷移するボタン -->
+        <% if item.cooldown_active? %>
+          <span class="badge badge-soft badge-info badge-outline text-sm rounded-full font-normal">
+            <%= item.remaining_time_text %>
+          </span>
+        <% else %>
+          <div class="btn-sm">
+            <%= render 'items/next_action_button', item: item %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/items/_compact_card.html.erb
+++ b/app/views/items/_compact_card.html.erb
@@ -21,9 +21,7 @@
             <%= item.remaining_time_text %>
           </span>
         <% else %>
-          <div class="btn-sm">
-            <%= render 'items/next_action_button', item: item %>
-          </div>
+          <%= render 'items/next_action_button', item: item, button_class: "btn-base min-w-[100px]" %>
         <% end %>
       </div>
     </div>

--- a/app/views/items/_cooldown_options.html.erb
+++ b/app/views/items/_cooldown_options.html.erb
@@ -1,0 +1,40 @@
+<div class="mb-12">
+  <div class="mb-3">
+    <p class="text-sm font-medium">クールダウンタイマー</p>
+    <p class="text-xs mt-1">※登録後に通知方法を設定できます</p>
+  </div>
+
+  <!-- 画面遷移図のような見た目に変更。スキップ選択後の再設定時は、選択肢にスキップを表示しない。 -->
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mx-3">
+    <% options =
+      if @item.cooldown_skipped?
+        @item.cooldown_options_for_select
+      else
+        @item.cooldown_options_for_select + [["今回は設定しない", "skip"]]
+      end %>
+
+    <% options.each do |label, value| %>
+      <label class="cursor-pointer group">
+        <%= radio_button_tag "cooldown_choice", value,
+          (params[:cooldown_choice] == value),
+          class: "hidden peer" %>
+
+        <div class="border rounded-xl pl-6 py-4 flex items-center justify-between
+                    hover:bg-gray-100 transition
+                    peer-checked:border-accent peer-checked:ring-2 peer-checked:ring-accent">
+
+          <div class="flex items-center gap-2">
+            <!-- 未選択 -->
+            <ion-icon name="radio-button-off-outline"
+                      class="text-xl group-has-[input:checked]:hidden"></ion-icon>
+            <!-- 選択 -->
+            <ion-icon name="radio-button-on-outline"
+                      class="text-xl hidden group-has-[input:checked]:inline text-accent"></ion-icon>
+
+            <span class="text-sm"><%= label %></span>
+          </div>
+        </div>
+      </label>
+    <% end %>
+  </div>
+</div>

--- a/app/views/items/_cooldown_options.html.erb
+++ b/app/views/items/_cooldown_options.html.erb
@@ -1,11 +1,11 @@
 <div class="mb-12">
   <div class="mb-3">
     <p class="text-sm font-medium">クールダウンタイマー</p>
-    <p class="text-xs mt-1">※登録後に通知方法を設定できます</p>
+    <p class="text-xs mt-1">少し時間を置いてみますか？（1商品につき1回、タイマーをセットすることができます）</p>
   </div>
 
   <!-- 画面遷移図のような見た目に変更。スキップ選択後の再設定時は、選択肢にスキップを表示しない。 -->
-  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mx-3">
+  <div class="grid grid-cols-1 gap-4 mx-3">
     <% options =
       if @item.cooldown_skipped?
         @item.cooldown_options_for_select
@@ -13,7 +13,9 @@
         @item.cooldown_options_for_select + [["今回は設定しない", "skip"]]
       end %>
 
-    <% options.each do |label, value| %>
+    <% options.each do |label, value, description| %>
+      <% is_hours_24 = (value == "hours_24") %>
+      <% is_skip = (value == "skip") %>
       <label class="cursor-pointer group">
         <%= radio_button_tag "cooldown_choice", value,
           (params[:cooldown_choice] == value),
@@ -23,7 +25,7 @@
                     hover:bg-gray-100 transition
                     peer-checked:border-accent peer-checked:ring-2 peer-checked:ring-accent">
 
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-4">
             <!-- 未選択 -->
             <ion-icon name="radio-button-off-outline"
                       class="text-xl group-has-[input:checked]:hidden"></ion-icon>
@@ -31,7 +33,18 @@
             <ion-icon name="radio-button-on-outline"
                       class="text-xl hidden group-has-[input:checked]:inline text-accent"></ion-icon>
 
-            <span class="text-sm"><%= label %></span>
+            <div class="flex flex-col">
+              <div class="flex items-center gap-1">
+                <div class="text-sm <%= is_skip ? "font-normal pt-1" : "font-medium" %>">
+                  <%= label %>
+                </div>
+                <% if is_hours_24 %>
+                  <p class="text-xs font-bold text-primary">迷ったらこちらをおすすめ</p>
+                <% end %>
+              </div>
+
+              <span class="text-xs mt-1"><%= description %></span>
+            </div>
           </div>
         </div>
       </label>

--- a/app/views/items/_cooldown_options.html.erb
+++ b/app/views/items/_cooldown_options.html.erb
@@ -10,7 +10,7 @@
       if @item.cooldown_skipped?
         @item.cooldown_options_for_select
       else
-        @item.cooldown_options_for_select + [["今回は設定しない", "skip"]]
+        @item.cooldown_options_for_select + [["今回はセットしない", "skip"]]
       end %>
 
     <% options.each do |label, value, description| %>

--- a/app/views/items/_next_action_button.html.erb
+++ b/app/views/items/_next_action_button.html.erb
@@ -1,19 +1,10 @@
-<div class="flex gap-2 flex-wrap justify-end gap-4">
-  <% if item.thinking? %>
+<% if item.thinking? %>
 
-    <!-- クールダウン設定へ -->
-    <!--
-    <% if item.cooldown_skipped? %>
-      <%= link_to "クールダウン", "#", class: "btn btn-outline min-w-[110px]" %>
-    <% end %>
-    -->
+  <% if item.drafted? %>
+    <%= link_to "続きから入力", purchase_decision_item_path(item), class: button_class %>
 
-    <!-- 購入判断画面へ -->
-    <% if item.drafted? %>
-      <%= link_to "続きから入力", purchase_decision_item_path(item), class: "btn-base min-w-[110px]" %>
-
-    <% elsif item.ready_for_decision? %>
-      <%= link_to "判断する", purchase_decision_item_path(item), class: "btn-base min-w-[110px]" %>
-    <% end %>
+  <% elsif item.ready_for_decision? %>
+    <%= link_to "判断する", purchase_decision_item_path(item), class: button_class %>
   <% end %>
-</div>
+
+<% end %>

--- a/app/views/items/_next_action_button.html.erb
+++ b/app/views/items/_next_action_button.html.erb
@@ -1,14 +1,19 @@
-<% if item.next_action.present? %>
-  <% action = item.next_action %>
+<div class="flex gap-2 flex-wrap justify-end gap-4">
+  <% if item.thinking? %>
 
-  <% path =
-    case action[:type]
-    when :cooldown
-      "#"
-    when :decision
-      purchase_decision_item_path(item)
-    end
-  %>
+    <!-- クールダウン設定へ -->
+    <!--
+    <% if item.cooldown_skipped? %>
+      <%= link_to "クールダウン", "#", class: "btn btn-outline min-w-[110px]" %>
+    <% end %>
+    -->
 
-  <%= link_to action[:label], path, class: "btn-base" %>
-<% end %>
+    <!-- 購入判断画面へ -->
+    <% if item.drafted? %>
+      <%= link_to "続きから入力", purchase_decision_item_path(item), class: "btn-base min-w-[110px]" %>
+
+    <% elsif item.ready_for_decision? %>
+      <%= link_to "判断する", purchase_decision_item_path(item), class: "btn-base min-w-[110px]" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/items/_status_badge.html.erb
+++ b/app/views/items/_status_badge.html.erb
@@ -1,19 +1,14 @@
 <% case item.status %>
 <% when "thinking" %>
-  <% if item.cooldown_not_selected? %>
-    <span class="badge badge-soft badge-primary text-xs">クールダウン未設定</span>
-  <% elsif item.cooldown_active? %>
-    <span class="badge badge-soft badge-primary text-xs">クールダウン中</span>
+  <% if item.cooldown_active? %>
+    <span class="badge badge-soft badge-info badge-outline text-xs rounded-xs font-normal">クールダウン中</span>
+  <% elsif item.drafted? %>
+    <span class="badge badge-soft badge-primary badge-outline text-xs rounded-full font-normal">購入判断を回答中</span>
   <% elsif item.cooldown_finished? %>
-    <span class="badge badge-soft badge-primary text-xs">クールダウン完了</span>
-  <!-- 追加予定:
-    質問回答が未回答、
-    質問回答が下書き(回答中)、
-    ジャーナリングが未回答、
-    ジャーナリングが下書き(回答中) -->
+    <span class="badge badge-soft badge-primary badge-outline text-xs rounded-full font-normal">クールダウン完了</span>
   <% end %>
 <% when "decided_buy" %>
-  <span class="badge badge-soft badge-accent text-xs">買う</span>
+  <span class="badge badge-soft badge-accent badge-outline text-xs rounded-full font-normal">買う</span>
 <% when "decided_skip" %>
-  <span class="badge badge-soft badge-info text-xs">買わない</span>
+  <span class="badge badge-soft badge-info badge-outline text-xs rounded-full font-normal">買わない</span>
 <% end %>

--- a/app/views/items/cooldown.html.erb
+++ b/app/views/items/cooldown.html.erb
@@ -6,7 +6,7 @@
       <%= render "shared/error_messages", object: f.object %>
 
       <!-- アイテム情報 -->
-      <div class="bg-base-200 rounded-lg opacity-90 my-12">
+      <div class="bg-base-200 rounded-sm opacity-90 my-12">
         <div class="p-1 ml-2">
           <p class="font-medium"><%= @item.name %></p>
 

--- a/app/views/items/cooldown.html.erb
+++ b/app/views/items/cooldown.html.erb
@@ -1,0 +1,40 @@
+<div class="max-w-2xl mx-auto my-8 px-4">
+  <div class="bg-white rounded-xl shadow px-8 py-10">
+    <h1 class="text-2xl font-bold mt-2 mb-9 text-center">クールダウンタイマーを使う</h1>
+
+    <%= form_with model: @item, url: set_cooldown_item_path(@item), method: :patch do |f| %>
+      <%= render "shared/error_messages", object: f.object %>
+
+      <!-- アイテム情報 -->
+      <div class="bg-base-200 rounded-lg opacity-90 my-12">
+        <div class="p-1 ml-2">
+          <p class="font-medium"><%= @item.name %></p>
+
+          <ion-icon name="calendar-outline" class="text-sm translate-y-[2px]"></ion-icon>
+          <span class="text-sm">
+            <%= @item.created_at.strftime("%Y/%-m/%-d") %>
+            <span class="mx-0.5"></span>
+            <%= @item.created_at.strftime("%-H:%M") %>に登録
+          </span>
+        </div>
+      </div>
+
+      <!-- クールダウンタイマー -->
+      <div class="max-w-xl">
+        <%= render 'items/cooldown_options' %>
+
+        <div class="flex text-sm justify-center gap-1 mb-7">
+          <ion-icon name="leaf-outline" class="text-lg"></ion-icon>
+          <p>クールダウン中は、次のステップに進めなくなります</p>
+        </div>
+
+        <!-- ボタン -->
+        <div class="flex flex-col items-center gap-6">
+          <%= submit_tag "設定する", class: "btn-base sm:w-auto min-w-[140px]" %>
+          <%= link_to "キャンセル", item_path(@item), class: "btn btn-outline w-fit sm:w-auto min-w-[140px]" %>
+        </div>
+      </div>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -13,7 +13,7 @@
         <%= render 'items/cooldown_options', f: f %>
 
         <!-- ボタン -->
-        <div class="flex flex-col items-center gap-4 mt-15 mb-3">
+        <div class="flex flex-col items-center gap-6 mt-12 mb-3">
           <%= f.submit "登録する", class: "btn-base sm:w-auto min-w-[140px]" %>
           <%= link_to "キャンセル", root_path, class: "btn btn-outline w-fit sm:w-auto min-w-[140px]" %>
         </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -10,40 +10,7 @@
         <%= render 'items/item_basic_form', f: f %>
 
         <!-- クールダウンタイマー -->
-        <div class="mb-12">
-          <div class="mb-3">
-            <p class="text-sm font-medium">クールダウンタイマー</p>
-            <p class="text-xs mt-1">※登録後に通知方法を設定できます</p>
-          </div>
-
-          <!-- カード -->
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mx-3">
-            <% (@item.cooldown_options_for_select + [["今回は設定しない", "skip"]]).each do |label, value| %>
-
-              <label class="cursor-pointer group">
-                <%= radio_button_tag "cooldown_choice", value,
-                  (params[:cooldown_choice] == value),
-                  class: "hidden peer" %>
-
-                <div class="border rounded-xl pl-6 py-4 flex items-center justify-between
-                            hover:bg-gray-100 transition
-                            peer-checked:border-accent peer-checked:ring-2 peer-checked:ring-accent">
-
-                  <div class="flex items-center gap-2">
-                    <!-- 未選択 -->
-                    <ion-icon name="radio-button-off-outline"
-                              class="text-xl group-has-[input:checked]:hidden"></ion-icon>
-                    <!-- 選択 -->
-                    <ion-icon name="radio-button-on-outline"
-                              class="text-xl hidden group-has-[input:checked]:inline text-accent"></ion-icon>
-
-                    <span class="text-sm"><%= label %></span>
-                  </div>
-                </div>
-              </label>
-            <% end %>
-          </div>
-        </div>
+        <%= render 'items/cooldown_options', f: f %>
 
         <!-- ボタン -->
         <div class="flex flex-col items-center gap-4 mt-15 mb-3">

--- a/app/views/items/purchase_decision.html.erb
+++ b/app/views/items/purchase_decision.html.erb
@@ -1,15 +1,17 @@
 <div class="max-w-3xl mx-auto my-8 px-4">
   <div class="bg-white rounded-xl shadow px-8 py-10 space-y-11">
     <div class="mt-2 mb-9 text-center">
-      <h1 class="text-2xl font-bold ">購入を判断する</h1>
+      <h1 class="text-2xl font-bold">購入を判断する</h1>
       <p class="text-sm mt-4">
         もしよろしければ、質問を活用しながら<br>
         買うかどうかを考えてみてください。
       </p>
     </div>
 
+    <%= render "shared/error_messages", object: @item %>
+
     <!-- アイテム情報 -->
-    <div class="bg-base-200 rounded-lg opacity-90">
+    <div class="bg-base-200 rounded-sm opacity-90">
       <div class="p-1 ml-2">
         <p class="font-medium"><%= @item.name %></p>
 
@@ -25,8 +27,8 @@
     <%= form_with model: @item, url: submit_decision_item_path(@item), method: :patch, local: true do |f| %>
 
       <!-- 質問（任意回答） -->
-      <h2 class="font-medium mb-5">質問から、気になった理由・買う理由を探してみる（任意）</h2>
-      <div class="space-y-4 mb-15 max-w-xl mx-auto">
+      <h2 class="font-medium mt-11 mb-5 ml-1">質問から、気になった理由・買う理由を探してみる（任意）</h2>
+      <div class="space-y-4 max-w-xl mx-auto">
 
         <!-- 欲しい度 -->
         <div class="space-y-2 text-center mb-8">
@@ -97,7 +99,7 @@
       </div>
 
       <!-- ジャーナリング（任意回答） -->
-      <div class="space-y-2">
+      <div class="space-y-2 mx-1">
         <h2 class="block font-medium mt-10 mb-2">ジャーナリングで、購入判断のきっかけを引き出してみる（任意）</h2>
         <p class="text-xs mt-1 leading-relaxed">
           このアイテムを手にすることで、あなたの日常はどのように彩られますか？<br>
@@ -108,13 +110,14 @@
         <%= f.text_area "journal_content",
             value: @journal&.content,
             rows:  6,
-            class: "textarea textarea-bordered w-full focus:outline-none" %>
+            class: "textarea textarea-bordered w-full focus:outline-none mt-1" %>
       </div>
 
       <div class="border-t border-base-300 my-12"></div>
 
       <!-- 購入判断 -->
-      <div class="space-y-4">
+      <div id="status-section" class="space-y-4">
+
         <p class="text-sm text-center">気持ちは決まりましたか？</p>
 
         <div class="grid grid-cols-2 gap-6 max-w-xs mx-auto">
@@ -159,13 +162,25 @@
         </div>
 
         <!-- 選択必須のメッセージ -->
-        <% if @item.errors[:status].any? %>
+        <% if @item.errors[:base].any? %>
           <div class="mt-5 flex justify-center">
             <div class="bg-error/10 border border-error/30 text-error px-4 py-2 rounded-full text-sm font-medium">
-              <ion-icon name="alert-circle-outline" class="mr-1 text-lg translate-y-[3px]"></ion-icon>
-              <%= @item.errors[:status].first %>
+              <ion-icon name="alert-circle" class="mr-1 text-lg translate-y-[3px]"></ion-icon>
+              <%= @item.errors[:base].first %>
             </div>
           </div>
+
+          <script>
+            requestAnimationFrame(() => {
+              const el = document.getElementById("status-section");
+              if (el) {
+                el.scrollIntoView({
+                  behavior: "auto",
+                  block: "center"
+                });
+              }
+            });
+          </script>
         <% end %>
       </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -33,9 +33,17 @@
       </div>
 
       <!-- クールダウンタイマー設定内容・残り時間 -->
-      <div class="flex gap-1">
+      <div class="flex gap-0.5">
         <ion-icon name="hourglass-outline" class="text-base translate-y-[5px]"></ion-icon>
-        <p><%= @item.cooldown_status_text %></p>
+        <% if @item.cooldown_active? %>
+          <p>
+            <%= @item.remaining_time_text %>でクールダウンが完了します
+          </p>
+        <% elsif @item.cooldown_skipped? %>
+          <p>クールダウンタイマーをスキップしました</p>
+        <% elsif @item.cooldown_finished? %>
+          <p class="ml-0.5"><%= @item.cooldown_duration_text %>のクールダウンが完了しました</p>
+        <% end %>
       </div>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -21,7 +21,8 @@
     </div>
 
     <!-- 日時情報 -->
-    <div class="text-md">
+    <div class="text-md leading-relaxed">
+      <!-- アイテム登録日時 -->
       <div class="flex gap-1">
         <ion-icon name="calendar-outline" class="text-base translate-y-[4px]"></ion-icon>
         <span>
@@ -31,10 +32,10 @@
         </span>
       </div>
 
-      <!-- クールダウンタイマー設定内容を追加 -->
+      <!-- クールダウンタイマー設定内容・残り時間 -->
       <div class="flex gap-1">
-        <ion-icon name="hourglass-outline" class="text-base translate-y-[4px]"></ion-icon>
-        <p>24時間のクールダウン中(あと3時間)</p>
+        <ion-icon name="hourglass-outline" class="text-base translate-y-[5px]"></ion-icon>
+        <p><%= @item.cooldown_status_text %></p>
       </div>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,8 +1,8 @@
 <div class="max-w-3xl mx-auto my-8 px-4">
   <div class="bg-white rounded-xl shadow px-6 py-10 space-y-6">
 
-    <div class="flex flex-row items-start justify-between gap-3">
-      <div class="flex flex-col gap-2">
+    <div class="flex flex-row items-start justify-between m-1 gap-5">
+      <div class="flex flex-col gap-3">
         <!-- アイテム名 -->
         <h1 class="text-2xl sm:text-3xl font-bold leading-tight">
           <%= @item.name %>
@@ -12,38 +12,42 @@
         <div>
           <%= render 'items/status_badge', item: @item %>
         </div>
+
+        <!-- 日時情報 -->
+        <div class="flex flex-col my-3 text-md leading-relaxed">
+          <!-- アイテム登録日時 -->
+          <div class="flex gap-1">
+            <ion-icon name="calendar-outline" class="text-base translate-y-[4px]"></ion-icon>
+            <span>
+              <%= @item.created_at.strftime("%Y/%-m/%-d") %>
+              <span class="mx-0.5"></span>
+              <%= @item.created_at.strftime("%-H:%M") %>に登録
+            </span>
+          </div>
+
+          <!-- クールダウンタイマー設定内容・残り時間 -->
+          <div class="flex gap-0.5">
+            <ion-icon name="hourglass-outline" class="text-base translate-y-[5px]"></ion-icon>
+            <% if @item.cooldown_active? %>
+              <p>
+                <%= @item.remaining_time_text %>でクールダウンが完了します
+              </p>
+            <% elsif @item.cooldown_skipped? %>
+              <p>クールダウンタイマーをスキップしました</p>
+            <% elsif @item.cooldown_finished? %>
+              <p class="ml-0.5"><%= @item.cooldown_duration_text %>のクールダウンが完了しました</p>
+            <% end %>
+          </div>
+        </div>
       </div>
 
       <!-- 次できるアクションに遷移するボタン -->
-      <div class="self-start sm:self-auto">
-        <%= render 'items/next_action_button', item: @item %>
-      </div>
-    </div>
-
-    <!-- 日時情報 -->
-    <div class="text-md leading-relaxed">
-      <!-- アイテム登録日時 -->
-      <div class="flex gap-1">
-        <ion-icon name="calendar-outline" class="text-base translate-y-[4px]"></ion-icon>
-        <span>
-          <%= @item.created_at.strftime("%Y/%-m/%-d") %>
-          <span class="mx-0.5"></span>
-          <%= @item.created_at.strftime("%-H:%M") %>に登録
-        </span>
-      </div>
-
-      <!-- クールダウンタイマー設定内容・残り時間 -->
-      <div class="flex gap-0.5">
-        <ion-icon name="hourglass-outline" class="text-base translate-y-[5px]"></ion-icon>
-        <% if @item.cooldown_active? %>
-          <p>
-            <%= @item.remaining_time_text %>でクールダウンが完了します
-          </p>
-        <% elsif @item.cooldown_skipped? %>
-          <p>クールダウンタイマーをスキップしました</p>
-        <% elsif @item.cooldown_finished? %>
-          <p class="ml-0.5"><%= @item.cooldown_duration_text %>のクールダウンが完了しました</p>
+      <div class="flex flex-col gap-4">
+        <% if @item.thinking? && @item.cooldown_skipped? %>
+          <%= link_to "クールダウン", cooldown_item_path(@item), class: "btn btn-info opacity-70 text-white min-w-[120px]" %>
         <% end %>
+
+        <%= render 'items/next_action_button', item: @item, button_class: "btn-base min-w-[120px]" %>
       </div>
     </div>
 

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -16,6 +16,12 @@ ja:
     enums:
       item:
         cooldown_duration:
-          minutes_30: "30分"
-          hours_24:   "24時間"
-          days_3:     "3日"
+          minutes_30:
+            label: "30分"
+            description: "とりあえず欲しい気持ちを落ち着かせたい時に"
+          hours_24:
+            label: "24時間（1日）"
+            description: "一晩置いてから考えたい時に"
+          days_3:
+            label: "72時間（3日）"
+            description: "頭をリセットしてじっくり考えたい時に"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,4 +21,5 @@ ja:
         validation:
           status_required: "「買う」「買わない」のどちらかを選択してください"
         access_denied:
+          cooldown_active: "クールダウンが終わるまで、次のステップに進めません"
           after_decision: "すでに購入判断は完了しています"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,6 +13,11 @@ ja:
         success: "削除しました"
         failure: "削除できませんでした"
       not_found: "アイテムが見つかりません"
+      cooldown:
+        success: "クールダウンタイマーをセットしました"
+        failure: "保存できませんでした"
+        validation:
+          already_used: "こちらの商品は、すでにクールダウンタイマーを使用しています"
       decide:
         success:
           complete: "購入判断を保存しました。おつかれさまでした！"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   resource :dashboards, only: [ :show ]
   resources :items, only: %i[index show new create edit update destroy] do
     member do
+      get :cooldown
+      patch :set_cooldown
+
       get :purchase_decision
       patch :submit_decision
     end

--- a/spec/requests/items_spec.rb
+++ b/spec/requests/items_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Items", type: :request do
         }
 
         expect(other_item.reload.name).not_to eq "不正更新"
-        expect(response).to have_http_status(:not_found)
+        expect(response).to redirect_to(items_path)
       end
     end
 


### PR DESCRIPTION
### 概要
クールダウンタイマー機能の追加と、デザイン調整を行いました。

### 内容
- クールダウンタイマー機能を追加（スキップ選択時には、後からクールダウンタイマーのセットが可能） 
- 画面遷移を調整
  - タイマー利用済みのアイテムはクールダウン画面に遷移できない
  - タイマー利用中は購入判断に進めない
  - 購入判断後はクールダウン・購入判断画面に遷移できない
  - ホーム画面・アイテム一覧に表示しているカード内で、アイテム名のクリックでもアイテム詳細に遷移できる
- アイテム名、ジャーナリングの最大文字数を修正
- デザイン調整
  - ホーム画面に要素を追加（今まで登録したアイテムカウント・検討中のアイテムを表示）
  - デザイン修正（クールダウンタイマーセット画面、クールダウン・購入判断に遷移するボタン、ステータスバッジ）
  - エラーメッセージの表示を修正
 
### 確認事項
- [x] 1アイテムにつき1回のみ、クールダウンタイマーをセットできる 
- [x] クールダウンタイマーの残り時間を、ホーム画面・アイテム一覧・アイテム詳細画面で確認できる
- クールダウンタイマーのアプリ内通知については、#11 で着手予定
- 今後のデザイン調整で、スキップ時のクールダウンセット画面への遷移方法を改善

closes #21
closes #25