### PR TITLE
fix: Itemsテーブルで下書き状態を管理するように変更

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -2,10 +2,10 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    items = current_user.items.includes(:answers, :journals)
+    items = current_user.items.includes(:answers, :journal).order(created_at: :desc)
 
     # 登録済みアイテムをカウント
-    @thinking_count     = items.thinking.count
+    @undecided_count    = items.undecided.count
     @decided_buy_count  = items.decided_buy.count
     @decided_skip_count = items.decided_skip.count
 
@@ -14,7 +14,7 @@ class DashboardsController < ApplicationController
     # クールダウン中のアイテム
     # スキップ選択時は後からタイマーを使う場合があるため、表示を最優先（クールダウン中は購入判断を行えない）
     cooldown_items_full = items
-      .thinking
+      .undecided
       .select(&:cooldown_active?)
 
     cooldown_ids = cooldown_items_full.map(&:id)
@@ -23,9 +23,9 @@ class DashboardsController < ApplicationController
 
     # 下書き中のアイテム
     draft_items_full = items
-      .thinking
+      .undecided
       .reject { |item| cooldown_ids.include?(item.id) }
-      .select { |item| draft_item?(item) }
+      .select { |item| item.drafting? }
 
     draft_ids = draft_items_full.map(&:id)
     @draft_items = draft_items_full.last(5)
@@ -34,17 +34,11 @@ class DashboardsController < ApplicationController
     # クールダウンが完了したアイテム
     # 下書き中アイテムとの二重表示を除外
     ready_items_full = items
-      .thinking
+      .undecided
       .reject { |item| cooldown_ids.include?(item.id) || draft_ids.include?(item.id) }
       .select(&:ready_for_decision?)
 
     @ready_items = ready_items_full.last(5)
     @ready_items_more = ready_items_full.size > 5
-  end
-
-  private
-
-  def draft_item?(item)
-    item.journals.any?(&:is_draft) || item.answers.any?(&:is_draft)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,16 +1,13 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_item, except: [ :index, :new, :create ]
+  before_action :prevent_access_after_decision, only: [ :cooldown, :set_cooldown, :purchase_decision, :submit_decision ]
   before_action :ensure_cooldown_not_set, only: [ :cooldown, :set_cooldown ]
   before_action :ensure_ready_for_decision, only: [ :purchase_decision, :submit_decision ]
-  before_action :prevent_access_after_decision, only: [ :cooldown, :set_cooldown, :purchase_decision, :submit_decision ]
 
   def index
     @items = current_user.items.order(created_at: :desc)
-
-    if params[:status].present?
-      @items = @items.where(status: params[:status])
-    end
+    @items = filter_items(@items)
   end
 
   def show; end
@@ -100,9 +97,9 @@ class ItemsController < ApplicationController
   # 購入判断
   # フォーム表示用
   def purchase_decision
-    @journal = @item.latest_draft_journal || @item.journals.build
     @questions = Question.where(user_id: nil).order(:position)
-    @answers_map = @item.answers.where(is_draft: true).index_by(&:question_id)
+    @answers_map = @item.answers.index_by(&:question_id)
+    @journal = @item.journal || @item.build_journal
 
     # フォーム送信後(paramsがある場合)は params 優先で上書き
     if answers_params.present?
@@ -127,7 +124,7 @@ class ItemsController < ApplicationController
 
     # 下書き保存
     when "draft"
-      save_draft
+      save_item(:drafting)
       redirect_to item_path(@item), success: t("flash.items.decide.success.draft")
 
     # 購入判断完了
@@ -150,10 +147,7 @@ class ItemsController < ApplicationController
       # バリデーションOK(購入判断「買う・買わない」を選択済み)
       else
         # 登録成功
-        ActiveRecord::Base.transaction do
-          finalize_decision(status_params)
-        end
-
+        save_item(status_params)
         redirect_to dashboards_path, success: t("flash.items.decide.success.complete")
       end
     end
@@ -170,31 +164,31 @@ class ItemsController < ApplicationController
 
   private
 
-  # 判断完了（購入判断完了ボタンをクリック後、バリデーションOK）
-  def finalize_decision(status)
-    @item.update!(status: status)
-    save_item_fields
-    save_answers(is_draft: false)
-    save_journal(is_draft: false)
+  def filter_items(items)
+    return items unless params[:status].present?
+
+    case params[:status]
+    when "undecided"
+      items.undecided
+    else
+      items.where(status: params[:status])
+    end
   end
 
-  # 下書き保存
-  def save_draft
-    save_item_fields
-    save_answers(is_draft: true)
-    save_journal(is_draft: true)
+  def save_item(status)
+    ActiveRecord::Base.transaction do
+      @item.update!(
+        status: status,
+        desire_level: params.dig(:item, :desire_level),
+        current_mood: params.dig(:item, :current_mood)
+      )
+
+      save_answers
+      save_journal
+    end
   end
 
-  # 欲しい度・今の気分を保存
-  def save_item_fields
-    @item.update!(
-      desire_level: params.dig(:item, :desire_level),
-      current_mood: params.dig(:item, :current_mood)
-    )
-  end
-
-  # 質問回答を保存
-  def save_answers(is_draft:)
+  def save_answers
     return if answers_params.blank?
 
     answers_params.each do |_, answer_param|
@@ -204,28 +198,19 @@ class ItemsController < ApplicationController
         question_id: answer_param["question_id"]
       )
 
-      answer.update!(
-        choice: answer_param[:choice],
-        is_draft: is_draft
-      )
+      answer.update!(choice: answer_param[:choice])
     end
   end
 
-  # ジャーナリングを保存
-  def save_journal(is_draft:)
-    return if journal_content.blank?
+  def save_journal
+    journal = @item.journal || @item.build_journal
 
-    if is_draft # 下書き
-      journal = @item.journals.find_or_initialize_by(is_draft: true)
-      journal.update!(content: journal_content)
-
-    else # 確定
-      journal = @item.journals.find_or_initialize_by(is_draft: true)
-      journal.update!(
-        content: journal_content,
-        is_draft: false
-      )
+    if journal_content.blank?
+      journal.destroy! if journal.persisted?
+      return
     end
+
+    journal.update!(content: journal_content)
   end
 
   # 購入判断完了ボタンをクリック後、失敗した場合(バリデーションエラーまたは登録失敗)
@@ -267,14 +252,14 @@ class ItemsController < ApplicationController
     redirect_to item_path(@item), alert: t("flash.items.cooldown.validation.already_used")
   end
 
-  # クールダウン完了前は、購入判断画面に遷移できない
+  # クールダウン完了前は遷移できない
   def ensure_ready_for_decision
     return if @item.ready_for_decision?
 
     redirect_to item_path(@item), alert: t("flash.items.decide.access_denied.cooldown_active")
   end
 
-  # 購入判断完了後は、購入判断画面に遷移できない
+  # 購入判断完了後は遷移できない
   def prevent_access_after_decision
     return unless @item.decided?
 

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,6 +1,5 @@
 class Answer < ApplicationRecord
   validates :question_id, uniqueness: { scope: :item_id }
-  validates :is_draft, inclusion: { in: [ true, false ] }
 
   enum :choice, { yes: 0, unknown: 1, no: 2 }
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,7 +15,7 @@ class Item < ApplicationRecord
   has_one :journal, dependent: :destroy
   has_many :answers, dependent: :destroy
 
-  scope :undecided, -> { where(status: [:thinking, :drafting]) }
+  scope :undecided, -> { where(status: [ :thinking, :drafting ]) }
 
   scope :cooldown_finished_unnotified, -> {
     where("cooldown_until <= ?", Time.current)
@@ -129,7 +129,7 @@ class Item < ApplicationRecord
   # 初回の購入判断後にdecided_atカラムを更新
   def set_decided_at
     return unless will_save_change_to_status?
-    return unless ["thinking", "drafting"].include?(status_was)
+    return unless [ "thinking", "drafting" ].include?(status_was)
     return unless decided?
 
     self.decided_at ||= Time.current

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,12 +8,14 @@ class Item < ApplicationRecord
   validates :note, length: { maximum: 65_535 }
   validate :cooldown_choice_valid
 
-  enum :status, { thinking: 0, decided_buy: 1, decided_skip: 2 }
+  enum :status, { thinking: 0, drafting: 1, decided_buy: 2, decided_skip: 3 }
   enum :cooldown_duration, { minutes_30: 0, hours_24: 1, days_3: 2 }
 
   belongs_to :user
-  has_many :journals, dependent: :destroy
+  has_one :journal, dependent: :destroy
   has_many :answers, dependent: :destroy
+
+  scope :undecided, -> { where(status: [:thinking, :drafting]) }
 
   scope :cooldown_finished_unnotified, -> {
     where("cooldown_until <= ?", Time.current)
@@ -21,43 +23,42 @@ class Item < ApplicationRecord
   }
 
   # アイテムのステータスを確認
-  def cooldown_skipped?
-    cooldown_duration.nil? && cooldown_until.present?
-    # クールダウンをスキップ時は、cooldown_untilに現在時刻を入れる
-  end
-
-  def cooldown_active?
-    cooldown_until.present? && cooldown_until > Time.current
-  end
-
-  def cooldown_finished?
-    cooldown_until.present? && cooldown_until <= Time.current
+  def undecided?
+    thinking? || drafting?
   end
 
   def ready_for_decision?
+    return false if decided?
     cooldown_skipped? || cooldown_finished?
-  end
-
-  def drafted?
-    journals.exists?(is_draft: true) || answers.exists?(is_draft: true)
   end
 
   def decided?
     decided_buy? || decided_skip?
   end
 
+  def cooldown_skipped?
+    cooldown_duration.nil? && cooldown_until.present?
+    # クールダウンをスキップ時は、cooldown_untilに現在時刻を入れる
+  end
+
+  def cooldown_active?
+    cooldown_duration.present? && cooldown_until > Time.current
+  end
+
+  def cooldown_finished?
+    cooldown_until.present? && cooldown_until <= Time.current
+  end
+
   def next_action_message
-    case status
-    when "thinking"
-      if cooldown_skipped?
-        "クールダウンタイマーのセットか、購入判断に進むことができます"
-      elsif cooldown_active?
-        "クールダウンが終わるまで、ひと休みしましょう"
-      elsif drafted?
-        "購入判断を再開できます"
-      elsif ready_for_decision?
-        "購入判断に進むことができます"
-      end
+    return if self.decided?
+    if cooldown_skipped?
+      "クールダウンタイマーのセットか、購入判断に進むことができます"
+    elsif cooldown_active?
+      "クールダウンが終わるまで、ひと休みしましょう"
+    elsif drafting?
+      "購入判断を再開できます"
+    elsif ready_for_decision?
+      "購入判断に進むことができます"
     end
   end
 
@@ -123,16 +124,12 @@ class Item < ApplicationRecord
     update!(notified_at: Time.current)
   end
 
-  def latest_draft_journal
-    journals.find_by(is_draft: true)
-  end
-
   private
 
   # 初回の購入判断後にdecided_atカラムを更新
   def set_decided_at
     return unless will_save_change_to_status?
-    return unless status_was == "thinking"
+    return unless ["thinking", "drafting"].include?(status_was)
     return unless decided?
 
     self.decided_at ||= Time.current

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,17 +1,6 @@
 class Journal < ApplicationRecord
+  validates :item_id, uniqueness: true
   validates :content, length: { maximum: 65_535 }
-  validates :is_draft, inclusion: { in: [ true, false ] }
-  validate :only_one_draft_per_item
 
   belongs_to :item
-
-  scope :published, -> { where(is_draft: false) }
-
-  def only_one_draft_per_item
-    return unless is_draft
-
-    if item.journals.where(is_draft: true).where.not(id: id).exists? # 自分以外にdraftが存在するか？
-      errors.add(:base, "下書きは1件まで保存可能です")
-    end
-  end
 end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -16,7 +16,7 @@
       <div class="card-body">
         <h2 class="card-title text-sm">検討中</h2>
         <p class="text-2xl font-bold">
-          <%= @thinking_count %>
+          <%= @undecided_count %>
         </p>
       </div>
     </div>
@@ -52,7 +52,7 @@
       <% end %>
       <% if @draft_items_more %>
         <div class="flex justify-center">
-          <%= link_to "すべて見る", items_path(status: "thinking"), class: "text-sm font-medium flex items-center gap-1" %>
+          <%= link_to "すべて見る", items_path(status: "undecided"), class: "text-sm font-medium flex items-center gap-1" %>
         </div>
       <% end %>
     </div>
@@ -67,7 +67,7 @@
       <% end %>
       <% if @ready_items_more %>
         <div class="flex justify-center">
-          <%= link_to "すべて見る", items_path(status: "thinking"), class: "text-sm font-medium flex items-center gap-1" %>
+          <%= link_to "すべて見る", items_path(status: "undecided"), class: "text-sm font-medium flex items-center gap-1" %>
         </div>
       <% end %>
     </div>
@@ -82,7 +82,7 @@
       <% end %>
       <% if @cooldown_items_more %>
         <div class="flex justify-center">
-          <%= link_to "すべて見る", items_path(status: "thinking"), class: "text-sm font-medium flex items-center gap-1" %>
+          <%= link_to "すべて見る", items_path(status: "undecided"), class: "text-sm font-medium flex items-center gap-1" %>
         </div>
       <% end %>
     </div>

--- a/app/views/items/_next_action_button.html.erb
+++ b/app/views/items/_next_action_button.html.erb
@@ -1,9 +1,9 @@
-<% if item.thinking? %>
+<% if item.ready_for_decision? %>
 
-  <% if item.drafted? %>
+  <% if item.drafting? %>
     <%= link_to "続きから入力", purchase_decision_item_path(item), class: button_class %>
 
-  <% elsif item.ready_for_decision? %>
+  <% elsif item.thinking? %>
     <%= link_to "判断する", purchase_decision_item_path(item), class: button_class %>
   <% end %>
 

--- a/app/views/items/_status_badge.html.erb
+++ b/app/views/items/_status_badge.html.erb
@@ -1,14 +1,15 @@
-<% case item.status %>
-<% when "thinking" %>
+<% if item.undecided? %>
   <% if item.cooldown_active? %>
     <span class="badge badge-soft badge-info badge-outline text-xs rounded-xs font-normal">クールダウン中</span>
-  <% elsif item.drafted? %>
+  <% elsif item.drafting? %>
     <span class="badge badge-soft badge-primary badge-outline text-xs rounded-full font-normal">購入判断を回答中</span>
   <% elsif item.cooldown_finished? %>
     <span class="badge badge-soft badge-primary badge-outline text-xs rounded-full font-normal">クールダウン完了</span>
   <% end %>
-<% when "decided_buy" %>
+
+<% elsif item.decided_buy? %>
   <span class="badge badge-soft badge-accent badge-outline text-xs rounded-full font-normal">買う</span>
-<% when "decided_skip" %>
+
+<% elsif item.decided_skip? %>
   <span class="badge badge-soft badge-info badge-outline text-xs rounded-full font-normal">買わない</span>
 <% end %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -9,7 +9,7 @@
   <!-- タブ -->
   <div class="tabs tabs-border mb-6 justify-center">
     <%= link_to "すべて", items_path, class: "tab px-8 #{params[:status].blank? ? 'tab-active' : ''}" %>
-    <%= link_to "検討中", items_path(status: "thinking"), class: "tab px-8 #{params[:status] == 'thinking' ? 'tab-active' : ''}" %>
+    <%= link_to "検討中", items_path(status: "undecided"), class: "tab px-8 #{params[:status] == 'undecided' ? 'tab-active' : ''}" %>
     <%= link_to "買う", items_path(status: "decided_buy"), class: "tab px-8 #{params[:status] == 'decided_buy' ? 'tab-active' : ''}" %>
     <%= link_to "買わない", items_path(status: "decided_skip"), class: "tab px-8 #{params[:status] == 'decided_skip' ? 'tab-active' : ''}" %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -43,7 +43,7 @@
 
       <!-- 次できるアクションに遷移するボタン -->
       <div class="flex flex-col gap-4">
-        <% if @item.thinking? && @item.cooldown_skipped? %>
+        <% if @item.cooldown_skipped? && @item.undecided? %>
           <%= link_to "クールダウン", cooldown_item_path(@item), class: "btn btn-info opacity-70 text-white min-w-[120px]" %>
         <% end %>
 
@@ -105,23 +105,25 @@
 
         <!-- 質問（8問） -->
         <div>
-          <% @item.answers.where(is_draft: false).each do |answer| %>
-            <div class="mt-3 mb-3">
-              <p class="text-sm font-medium opacity-90">
-                <%= answer.question.content %>
-              </p>
+          <% if @item.decided? %>
+            <% @item.answers.each do |answer| %>
+              <div class="mt-3 mb-3">
+                <p class="text-sm font-medium opacity-90">
+                  <%= answer.question.content %>
+                </p>
 
-              <div class="flex gap-2 mt-1">
-                <% Answer.choices.keys.each do |key| %>
-                  <% selected = answer.choice == key %>
+                <div class="flex gap-2 mt-1">
+                  <% Answer.choices.keys.each do |key| %>
+                    <% selected = answer.choice == key %>
 
-                  <span class="px-3 py-1 rounded-full text-xs border
-                    <%= selected ? 'bg-primary text-white' : 'opacity-40' %>">
-                    <%= { yes: "はい", unknown: "わからない", no: "いいえ" }[key.to_sym] %>
-                  </span>
-                <% end %>
+                    <span class="px-3 py-1 rounded-full text-xs border
+                      <%= selected ? 'bg-primary text-white' : 'opacity-40' %>">
+                      <%= { yes: "はい", unknown: "わからない", no: "いいえ" }[key.to_sym] %>
+                    </span>
+                  <% end %>
+                </div>
               </div>
-            </div>
+            <% end %>
           <% end %>
         </div>
 
@@ -132,10 +134,8 @@
     <div class="bg-gray-50 rounded-lg p-4 space-y-2">
       <p class="text-xs font-bold opacity-90">ジャーナリング</p>
       <div class="text-sm leading-relaxed">
-        <% if @item.journals.published.any? %>
-          <% @item.journals.published.each do |journal| %>
-            <%= simple_format(journal.content) if journal.content.present? %>
-          <% end %>
+        <% if @item.decided? && @item.journal&.content.present? %>
+          <%= simple_format(@item.journal.content) %>
         <% else %>
           <p class="text-sm text-gray-400 italic">
             まだ登録されていません

--- a/db/migrate/20260424071052_remove_isdraft_from_tables.rb
+++ b/db/migrate/20260424071052_remove_isdraft_from_tables.rb
@@ -1,0 +1,6 @@
+class RemoveIsdraftFromTables < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :answers,  :is_draft
+    remove_column :journals, :is_draft
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_15_120021) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_071052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "answers", force: :cascade do |t|
     t.integer "choice"
     t.datetime "created_at", null: false
-    t.boolean "is_draft", default: true, null: false
     t.bigint "item_id", null: false
     t.bigint "question_id", null: false
     t.datetime "updated_at", null: false
@@ -46,10 +45,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_15_120021) do
   create_table "journals", force: :cascade do |t|
     t.text "content"
     t.datetime "created_at", null: false
-    t.boolean "is_draft", default: true, null: false
     t.bigint "item_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["item_id"], name: "index_journals_unique_draft_per_item", unique: true, where: "(is_draft = true)"
   end
 
   create_table "questions", force: :cascade do |t|


### PR DESCRIPTION
### 概要
下書き保存時の状態管理方法を変更しました。

### 内容
当初はAnswersテーブルとJournalsテーブルのis_draftカラムで下書き状態の管理を行っていました。
しかし、質問回答とジャーナリングを同じ画面で行うよう変更したことや
購入判断は1アイテムにつき1回という方針にしたことによって、
テーブルごとに下書き状態を管理する必要がなくなったので、Itemsテーブルで管理する方法に修正を行いました。